### PR TITLE
feat: 敵AI強化 — 状態機械による追跡・タイプ別行動 (#5)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -1,7 +1,7 @@
 import { useGameStore } from '~/stores/gameStore'
 import { TurnManager } from '~/game/systems/TurnManager'
 import { CombatSystem } from '~/game/systems/CombatSystem'
-import { randomMove } from '~/game/systems/EnemyAI'
+import { decideAction } from '~/game/systems/EnemyAI'
 import { ITEMS } from '~/game/data/items'
 import { generateFloor } from '~/game/systems/DungeonGenerator'
 import { getFloorDifficulty } from '~/game/data/floorConfig'
@@ -87,25 +87,31 @@ export function useGameLoop() {
     const events: CombatEvent[] = []
 
     for (const enemy of store.enemies) {
-      // 隣接判定（4方向）
-      const dx = Math.abs(enemy.x - playerPos.x)
-      const dy = Math.abs(enemy.y - playerPos.y)
-      const isAdjacent = (dx === 1 && dy === 0) || (dx === 0 && dy === 1)
+      const occupied = [
+        playerPos,
+        ...store.enemies.filter((e) => e.id !== enemy.id).map((e) => ({ x: e.x, y: e.y })),
+      ]
+      const action = decideAction(
+        {
+          x: enemy.x,
+          y: enemy.y,
+          type: enemy.type,
+          aiState: (enemy.aiState ?? 'idle') as 'idle' | 'chase' | 'attack',
+        },
+        playerPos,
+        map,
+        occupied
+      )
 
-      if (isAdjacent) {
+      store.setEnemyAIState(enemy.id, action.newAIState)
+
+      if (action.type === 'attack') {
         const { messages: msgs, event } = enemyAttackPlayer(enemy)
         messages.push(...msgs)
         events.push(event)
         if (store.player.hp <= 0) break
-      } else {
-        const occupied = [
-          playerPos,
-          ...store.enemies.filter((e) => e.id !== enemy.id).map((e) => ({ x: e.x, y: e.y })),
-        ]
-        const newPos = randomMove({ x: enemy.x, y: enemy.y }, map, occupied)
-        if (newPos) {
-          store.moveEnemy(enemy.id, newPos.x, newPos.y)
-        }
+      } else if (action.type === 'move') {
+        store.moveEnemy(enemy.id, action.position.x, action.position.y)
       }
     }
     return { messages, events }

--- a/game/entities/Enemy.ts
+++ b/game/entities/Enemy.ts
@@ -33,6 +33,7 @@ export interface EnemyStoreState {
   attack: number
   defense: number
   exp: number
+  aiState: string
 }
 
 export class Enemy {
@@ -118,6 +119,7 @@ export class Enemy {
       attack: this.data.attack,
       defense: this.data.defense,
       exp: this.data.exp,
+      aiState: this.data.aiState,
     }
   }
 

--- a/game/systems/EnemyAI.ts
+++ b/game/systems/EnemyAI.ts
@@ -3,12 +3,45 @@ interface Position {
   y: number
 }
 
+type AIState = 'idle' | 'chase' | 'attack'
+
+export interface EnemyWithState {
+  x: number
+  y: number
+  type: string
+  aiState: AIState
+}
+
+export type EnemyAction =
+  | { type: 'move'; position: Position; newAIState: AIState }
+  | { type: 'attack'; newAIState: AIState }
+  | { type: 'idle'; newAIState: AIState }
+
 const DIRECTIONS = [
   { dx: 0, dy: -1 }, // 上
   { dx: 0, dy: 1 }, // 下
   { dx: -1, dy: 0 }, // 左
   { dx: 1, dy: 0 }, // 右
 ]
+
+const AI_CONFIG: Record<string, { detectRange: number; chaseRange: number }> = {
+  skeleton: { detectRange: 4, chaseRange: 6 },
+  goblin: { detectRange: 6, chaseRange: 8 },
+}
+
+function getAIConfig(type: string) {
+  return AI_CONFIG[type] ?? { detectRange: 4, chaseRange: 6 }
+}
+
+function chebyshevDistance(a: Position, b: Position): number {
+  return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y))
+}
+
+export function isAdjacent(a: Position, b: Position): boolean {
+  const dx = Math.abs(a.x - b.x)
+  const dy = Math.abs(a.y - b.y)
+  return (dx === 1 && dy === 0) || (dx === 0 && dy === 1)
+}
 
 /**
  * ランダム移動AI
@@ -27,15 +60,88 @@ export function randomMove(
     const nx = enemy.x + dx
     const ny = enemy.y + dy
 
-    // 範囲外チェック
     if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) continue
-    // 壁チェック
     if (map[ny][nx] === 1) continue
-    // 他エンティティとの重複チェック
     if (occupied.some((p) => p.x === nx && p.y === ny)) continue
 
     return { x: nx, y: ny }
   }
 
   return null
+}
+
+/**
+ * プレイヤー方向への貪欲移動
+ * dx/dyの大きい方を優先し、壁ならもう一方を試行
+ */
+export function moveToward(
+  enemy: Position,
+  target: Position,
+  map: number[][],
+  occupied: Position[]
+): Position | null {
+  const dx = target.x - enemy.x
+  const dy = target.y - enemy.y
+
+  // 優先方向を決定（距離が大きい軸を先に試す）
+  const candidates: { nx: number; ny: number }[] = []
+
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    if (dx !== 0) candidates.push({ nx: enemy.x + Math.sign(dx), ny: enemy.y })
+    if (dy !== 0) candidates.push({ nx: enemy.x, ny: enemy.y + Math.sign(dy) })
+  } else {
+    if (dy !== 0) candidates.push({ nx: enemy.x, ny: enemy.y + Math.sign(dy) })
+    if (dx !== 0) candidates.push({ nx: enemy.x + Math.sign(dx), ny: enemy.y })
+  }
+
+  for (const { nx, ny } of candidates) {
+    if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) continue
+    if (map[ny][nx] === 1) continue
+    if (occupied.some((p) => p.x === nx && p.y === ny)) continue
+    return { x: nx, y: ny }
+  }
+
+  return null
+}
+
+/**
+ * 敵の行動決定（状態機械）
+ */
+export function decideAction(
+  enemy: EnemyWithState,
+  playerPos: Position,
+  map: number[][],
+  occupied: Position[]
+): EnemyAction {
+  const config = getAIConfig(enemy.type)
+  const dist = chebyshevDistance(enemy, playerPos)
+  let state = enemy.aiState
+
+  // 状態遷移
+  if (state === 'idle' && dist <= config.detectRange) {
+    state = 'chase'
+  } else if (state === 'chase' && dist > config.chaseRange) {
+    state = 'idle'
+  }
+
+  // 隣接ならattack
+  if (isAdjacent(enemy, playerPos)) {
+    return { type: 'attack', newAIState: 'chase' }
+  }
+
+  // chase状態: プレイヤーに向かって移動
+  if (state === 'chase') {
+    const pos = moveToward(enemy, playerPos, map, occupied)
+    if (pos) {
+      return { type: 'move', position: pos, newAIState: 'chase' }
+    }
+    return { type: 'idle', newAIState: 'chase' }
+  }
+
+  // idle状態: ランダム移動
+  const pos = randomMove(enemy, map, occupied)
+  if (pos) {
+    return { type: 'move', position: pos, newAIState: 'idle' }
+  }
+  return { type: 'idle', newAIState: 'idle' }
 }

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -23,6 +23,7 @@ interface EnemyState {
   attack: number
   defense: number
   exp: number
+  aiState: string
 }
 
 interface FloorItem {
@@ -156,6 +157,13 @@ export const useGameStore = defineStore('game', {
       if (enemy) {
         enemy.x = x
         enemy.y = y
+      }
+    },
+
+    setEnemyAIState(id: string, state: string) {
+      const enemy = this.enemies.find((e) => e.id === id)
+      if (enemy) {
+        enemy.aiState = state
       }
     },
 

--- a/tests/unit/entities/Enemy.test.ts
+++ b/tests/unit/entities/Enemy.test.ts
@@ -98,6 +98,7 @@ describe('Enemy（共通機能）', () => {
         attack: 5,
         defense: 2,
         exp: 10,
+        aiState: 'idle',
       })
     })
   })

--- a/tests/unit/systems/EnemyAI.test.ts
+++ b/tests/unit/systems/EnemyAI.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { randomMove } from '../../../game/systems/EnemyAI'
+import { randomMove, moveToward, isAdjacent, decideAction } from '../../../game/systems/EnemyAI'
 
 const map = [
   [1, 1, 1, 1, 1],
@@ -20,7 +20,6 @@ describe('EnemyAI', () => {
     })
 
     it('壁には移動しない', () => {
-      // (1,1)の左と上は壁
       for (let i = 0; i < 50; i++) {
         const result = randomMove({ x: 1, y: 1 }, map, [])
         if (result) {
@@ -53,6 +52,103 @@ describe('EnemyAI', () => {
     it('空マップでnullを返す', () => {
       const result = randomMove({ x: 0, y: 0 }, [], [])
       expect(result).toBeNull()
+    })
+  })
+
+  describe('isAdjacent', () => {
+    it('隣接マスでtrue', () => {
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 2 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 2, y: 3 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 1, y: 2 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 2, y: 1 })).toBe(true)
+    })
+
+    it('斜めはfalse', () => {
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 3 })).toBe(false)
+    })
+
+    it('離れていたらfalse', () => {
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 4, y: 2 })).toBe(false)
+    })
+
+    it('同じ位置はfalse', () => {
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 2, y: 2 })).toBe(false)
+    })
+  })
+
+  describe('moveToward', () => {
+    it('ターゲット方向に近づく', () => {
+      const result = moveToward({ x: 1, y: 1 }, { x: 3, y: 1 }, map, [])
+      expect(result).toEqual({ x: 2, y: 1 })
+    })
+
+    it('壁で塞がれたらもう一方の軸を試す', () => {
+      // 右が壁の場合、下に移動
+      const narrowMap = [
+        [1, 1, 1, 1, 1],
+        [1, 0, 1, 0, 1],
+        [1, 0, 0, 0, 1],
+        [1, 1, 1, 1, 1],
+      ]
+      const result = moveToward({ x: 1, y: 1 }, { x: 3, y: 2 }, narrowMap, [])
+      expect(result).toEqual({ x: 1, y: 2 })
+    })
+
+    it('完全に塞がれたらnull', () => {
+      const occupied = [
+        { x: 2, y: 1 },
+        { x: 1, y: 2 },
+      ]
+      const result = moveToward({ x: 1, y: 1 }, { x: 3, y: 3 }, map, occupied)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('decideAction', () => {
+    it('idle + 検知範囲内 → chase + move', () => {
+      const enemy = { x: 1, y: 1, type: 'skeleton', aiState: 'idle' as const }
+      const action = decideAction(enemy, { x: 3, y: 1 }, map, [])
+      expect(action.newAIState).toBe('chase')
+      expect(action.type).toBe('move')
+    })
+
+    it('idle + 検知範囲外 → idle', () => {
+      const bigMap = Array.from({ length: 20 }, () => Array(20).fill(0))
+      const enemy = { x: 1, y: 1, type: 'skeleton', aiState: 'idle' as const }
+      const action = decideAction(enemy, { x: 15, y: 15 }, bigMap, [])
+      expect(action.newAIState).toBe('idle')
+    })
+
+    it('隣接 → attack', () => {
+      const enemy = { x: 2, y: 2, type: 'skeleton', aiState: 'idle' as const }
+      const action = decideAction(enemy, { x: 3, y: 2 }, map, [])
+      expect(action.type).toBe('attack')
+    })
+
+    it('chase + 範囲外 → idle', () => {
+      const bigMap = Array.from({ length: 20 }, () => Array(20).fill(0))
+      const enemy = { x: 1, y: 1, type: 'skeleton', aiState: 'chase' as const }
+      const action = decideAction(enemy, { x: 15, y: 15 }, bigMap, [])
+      expect(action.newAIState).toBe('idle')
+    })
+
+    it('ゴブリンはスケルトンより広い検知範囲', () => {
+      const bigMap = Array.from({ length: 20 }, () => Array(20).fill(0))
+      // 距離5: スケルトン検知外(4)、ゴブリン検知内(6)
+      const skeletonAction = decideAction(
+        { x: 1, y: 1, type: 'skeleton', aiState: 'idle' as const },
+        { x: 6, y: 1 },
+        bigMap,
+        []
+      )
+      const goblinAction = decideAction(
+        { x: 1, y: 1, type: 'goblin', aiState: 'idle' as const },
+        { x: 6, y: 1 },
+        bigMap,
+        []
+      )
+      expect(skeletonAction.newAIState).toBe('idle')
+      expect(goblinAction.newAIState).toBe('chase')
     })
   })
 })


### PR DESCRIPTION
旧PR #51 がbase branch削除で自動closeされたため再作成。mainにrebaseし直して敵AI強化コミットだけを載せた。

## Summary
- decideAction: idle→chase→attack の状態機械AI
- moveToward: プレイヤー方向への貪欲移動
- isAdjacent: 4方向隣接判定
- スケルトン: 検知範囲4、追跡範囲6
- ゴブリン: 検知範囲6、追跡範囲8
- EnemyStateにaiState追加、processEnemyTurnでdecideAction使用
- テスト12件追加

Closes #5

## Test plan
- [x] 単体テスト通過済み（旧PR #51のCI）
- [ ] 新規PRのCI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)