### PR TITLE
feat: 死亡・ゲームオーバー処理＋リザルト画面 (#7, #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ logs
 .env.*
 !.env.example
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Test artifacts
 test-results/

--- a/components/GameCanvas.client.vue
+++ b/components/GameCanvas.client.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import Phaser from 'phaser'
-  import { markRaw, nextTick, onMounted, onUnmounted, ref } from 'vue'
+  import { markRaw, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
   import { DungeonScene } from '~/phaser/scenes/DungeonScene'
   import { UIScene } from '~/phaser/scenes/UIScene'
   import { useGameStore } from '~/stores/gameStore'
@@ -10,6 +10,7 @@
   let game: Phaser.Game | null = null
   const gameStore = useGameStore()
   const gameLoop = useGameLoop()
+  const router = useRouter()
 
   function createGame(parent: HTMLDivElement): Phaser.Game {
     return new Phaser.Game({
@@ -43,10 +44,26 @@
       gameLoop.initDungeon(gameStore.dungeon.dungeonId)
     }
 
+    // 復元時にゲーム終了状態ならリザルトへ直接遷移
+    if (gameStore.gameResult !== 'active') {
+      router.replace('/gameover')
+      return
+    }
+
     // 状態変更時にsessionStorageへ自動保存（Game生成前に開始）
     gameStore.$subscribe(() => {
       gameStore.saveToSession()
     })
+
+    // ゲームオーバー・クリア時にリザルト画面へ遷移
+    watch(
+      () => gameStore.gameResult,
+      (result) => {
+        if (result === 'dead' || result === 'cleared') {
+          router.push('/gameover')
+        }
+      }
+    )
 
     game = markRaw(createGame(gameContainer.value))
   })

--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -156,6 +156,7 @@ export function useGameLoop() {
         const updated = store.enemies.find((e) => e.id === target.id)
         if (!updated || updated.hp <= 0) {
           store.removeEnemy(target.id)
+          store.incrementDefeatedEnemies()
           messages.push(`${name}を倒した！`)
           store.gainExp(target.exp)
           killed = true

--- a/pages/gameover.vue
+++ b/pages/gameover.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+  import { computed, onMounted } from 'vue'
+  import { useGameStore } from '~/stores/gameStore'
+
+  const router = useRouter()
+  const gameStore = useGameStore()
+
+  const isDead = computed(() => gameStore.gameResult === 'dead')
+  const isCleared = computed(() => gameStore.gameResult === 'cleared')
+
+  const title = computed(() => (isCleared.value ? 'GAME CLEAR' : 'GAME OVER'))
+  const subtitle = computed(() => (isCleared.value ? '〜 深淵を制した 〜' : '〜 力尽きた 〜'))
+
+  const finalFloor = computed(() => gameStore.maxFloorReached)
+  const finalLevel = computed(() => gameStore.player.level)
+  const defeatedCount = computed(() => gameStore.defeatedEnemies)
+
+  onMounted(() => {
+    // 不正遷移対策: activeのままならタイトルへ戻す
+    if (gameStore.gameResult === 'active') {
+      router.replace('/')
+    }
+  })
+
+  const backToTitle = () => {
+    sessionStorage.removeItem('gameState')
+    gameStore.resetGame()
+    router.push('/')
+  }
+</script>
+
+<template>
+  <div class="gameover-screen" :class="{ 'is-cleared': isCleared, 'is-dead': isDead }">
+    <div class="result-area">
+      <h1 class="title">{{ title }}</h1>
+      <p class="subtitle">{{ subtitle }}</p>
+    </div>
+
+    <div class="stats nes-container is-dark is-rounded">
+      <dl class="stat-list">
+        <div class="stat-row">
+          <dt>到達階層</dt>
+          <dd>{{ finalFloor }} F</dd>
+        </div>
+        <div class="stat-row">
+          <dt>最終レベル</dt>
+          <dd>Lv. {{ finalLevel }}</dd>
+        </div>
+        <div class="stat-row">
+          <dt>撃破数</dt>
+          <dd>{{ defeatedCount }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="menu">
+      <button class="nes-btn is-primary menu-btn" @click="backToTitle">タイトルへ</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .gameover-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background-color: #1a1a2e;
+    color: #fff;
+    padding: 2rem 1rem;
+    font-family: 'DotGothic16', monospace;
+  }
+
+  .gameover-screen.is-dead {
+    background-color: #2a0a0a;
+  }
+
+  .gameover-screen.is-cleared {
+    background-color: #1a2e1a;
+  }
+
+  .result-area {
+    text-align: center;
+  }
+
+  .title {
+    font-size: 1.8rem;
+    margin: 0 0 0.5rem;
+    letter-spacing: 0.1em;
+  }
+
+  .is-dead .title {
+    color: #ff4444;
+  }
+
+  .is-cleared .title {
+    color: #ffdd00;
+  }
+
+  .subtitle {
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+
+  .stats {
+    width: 100%;
+    max-width: 320px;
+    padding: 1.2rem !important;
+  }
+
+  .stat-list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  .stat-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+  }
+
+  .stat-row dt {
+    margin: 0;
+    opacity: 0.8;
+  }
+
+  .stat-row dd {
+    margin: 0;
+    font-weight: bold;
+  }
+
+  .menu {
+    width: 100%;
+    max-width: 280px;
+  }
+
+  .menu-btn {
+    width: 100%;
+    padding: 0.8rem 1rem !important;
+    font-size: 0.8rem !important;
+  }
+
+  @media (min-width: 480px) {
+    .title {
+      font-size: 2.4rem;
+    }
+
+    .subtitle {
+      font-size: 0.9rem;
+    }
+
+    .stat-row {
+      font-size: 0.9rem;
+    }
+
+    .menu {
+      max-width: 320px;
+    }
+
+    .menu-btn {
+      padding: 1rem 1.5rem !important;
+      font-size: 0.9rem !important;
+    }
+  }
+</style>

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -214,8 +214,8 @@ export class DungeonScene extends Phaser.Scene {
 
         // ダンジョンクリア判定
         if (result && typeof result === 'object' && 'cleared' in result) {
-          overlay.destroy()
           this.updateUI(result.messages)
+          this.playClearSequence(overlay)
           return
         }
 
@@ -706,7 +706,11 @@ export class DungeonScene extends Phaser.Scene {
         this.drawScene()
         this.playCombatEffects(result.enemyEvents)
         this.time.delayedCall(300, () => {
-          this.inputLocked = false
+          if (this.gameStore.player.hp <= 0 && this.gameStore.gameResult === 'active') {
+            this.playDeathSequence()
+          } else {
+            this.inputLocked = false
+          }
         })
       })
     } else {
@@ -714,6 +718,100 @@ export class DungeonScene extends Phaser.Scene {
         this.inputLocked = false
       })
     }
+  }
+
+  private playDeathSequence() {
+    this.inputLocked = true
+    this.stopBgm()
+
+    // プレイヤー位置に赤フラッシュ
+    const playerPos = this.gameStore.player.position
+    const pos = this.tileToScreen(playerPos.x, playerPos.y)
+    const redFlash = this.add.rectangle(
+      this.screenWidth / 2,
+      this.screenHeight / 2,
+      this.screenWidth,
+      this.screenHeight,
+      0x880000
+    )
+    redFlash.setAlpha(0)
+    redFlash.setDepth(2500)
+
+    const centerFlash = this.add.rectangle(
+      pos.x,
+      pos.y - this.tileHeight * 0.4,
+      this.tileWidth * 2,
+      this.tileHeight * 2,
+      0xff2222
+    )
+    centerFlash.setAlpha(0.7)
+    centerFlash.setDepth(1500)
+
+    this.tweens.add({
+      targets: redFlash,
+      alpha: 0.6,
+      duration: 400,
+      ease: 'Power2',
+    })
+    this.tweens.add({
+      targets: centerFlash,
+      alpha: 0,
+      scaleX: 2.5,
+      scaleY: 2.5,
+      duration: 500,
+      ease: 'Power2',
+      onComplete: () => centerFlash.destroy(),
+    })
+
+    // 暗転オーバーレイ
+    const blackout = this.add.rectangle(
+      this.screenWidth / 2,
+      this.screenHeight / 2,
+      this.screenWidth,
+      this.screenHeight,
+      0x000000
+    )
+    blackout.setAlpha(0)
+    blackout.setDepth(3000)
+
+    // メッセージ
+    this.time.delayedCall(600, () => {
+      this.tweens.add({
+        targets: blackout,
+        alpha: 1,
+        duration: 800,
+        ease: 'Power2',
+        onComplete: () => {
+          const deathText = this.add.text(
+            this.screenWidth / 2,
+            this.screenHeight / 2,
+            '力尽きた...',
+            {
+              fontSize: '28px',
+              fontFamily: '"DotGothic16", monospace',
+              color: '#ff4444',
+              stroke: '#000000',
+              strokeThickness: 4,
+            }
+          )
+          deathText.setOrigin(0.5)
+          deathText.setDepth(3001)
+          deathText.setAlpha(0)
+
+          this.tweens.add({
+            targets: deathText,
+            alpha: 1,
+            duration: 500,
+            ease: 'Power2',
+            onComplete: () => {
+              this.time.delayedCall(1200, () => {
+                this.gameStore.setGameResult('dead')
+              })
+            },
+          })
+        },
+      })
+    })
   }
 
   private playCombatEffects(events: CombatEvent[]) {
@@ -798,6 +896,39 @@ export class DungeonScene extends Phaser.Scene {
       duration: 200,
       ease: 'Power2',
       onComplete: () => flash.destroy(),
+    })
+  }
+
+  private playClearSequence(overlay: Phaser.GameObjects.Rectangle) {
+    this.stopBgm()
+
+    const clearText = this.add.text(
+      this.screenWidth / 2,
+      this.screenHeight / 2,
+      'ダンジョン踏破！',
+      {
+        fontSize: '28px',
+        fontFamily: '"DotGothic16", monospace',
+        color: '#ffdd00',
+        stroke: '#000000',
+        strokeThickness: 4,
+      }
+    )
+    clearText.setOrigin(0.5)
+    clearText.setDepth(3001)
+    clearText.setAlpha(0)
+
+    this.tweens.add({
+      targets: clearText,
+      alpha: 1,
+      duration: 600,
+      ease: 'Power2',
+      onComplete: () => {
+        this.time.delayedCall(1500, () => {
+          this.gameStore.setGameResult('cleared')
+          overlay.destroy()
+        })
+      },
     })
   }
 

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -44,6 +44,8 @@ interface DungeonState {
   totalFloors: number
 }
 
+export type GameResult = 'active' | 'dead' | 'cleared'
+
 interface GameState {
   player: PlayerState
   dungeon: DungeonState
@@ -54,6 +56,9 @@ interface GameState {
   messageLog: string[]
   currentMap: number[][]
   exploredTiles: string[] // "x,y" 形式の探索済み座標
+  gameResult: GameResult
+  defeatedEnemies: number
+  maxFloorReached: number
 }
 
 export const useGameStore = defineStore('game', {
@@ -82,6 +87,9 @@ export const useGameStore = defineStore('game', {
     messageLog: [],
     currentMap: [],
     exploredTiles: [],
+    gameResult: 'active',
+    defeatedEnemies: 0,
+    maxFloorReached: 1,
   }),
 
   getters: {
@@ -114,6 +122,17 @@ export const useGameStore = defineStore('game', {
 
     nextFloor() {
       this.dungeon.floor++
+      if (this.dungeon.floor > this.maxFloorReached) {
+        this.maxFloorReached = this.dungeon.floor
+      }
+    },
+
+    setGameResult(result: GameResult) {
+      this.gameResult = result
+    },
+
+    incrementDefeatedEnemies() {
+      this.defeatedEnemies++
     },
 
     setDungeon(dungeonId: string, totalFloors: number) {


### PR DESCRIPTION
## Summary
- プレイヤーHP0検出→赤フラッシュ＋暗転→「力尽きた...」演出
- ダンジョン踏破時の「ダンジョン踏破！」演出
- \`/gameover\` ページ: GAME OVER / GAME CLEAR 切替、到達階層・最終レベル・撃破数表示
- gameStoreに \`gameResult\`, \`maxFloorReached\`, \`defeatedEnemies\` 追加
- リロード時に終了状態なら自動でリザルト画面へ遷移
- \`.claude/scheduled_tasks.lock\` をgitignore追加

## 実装

死亡検知は \`DungeonScene.playSequencedCombatEffects\` の末尾で \`store.player.hp <= 0 && store.gameResult === 'active'\` を判定し、\`playDeathSequence\` を発火。

リザルト遷移はGameCanvas.client.vue側で \`gameStore.gameResult\` をwatchし、'dead'/'cleared' になったら \`router.push('/gameover')\`。

ダンジョン踏破は既存の \`goNextFloor\` が返す \`{ cleared: true }\` 経路を \`playClearSequence\` に渡す形で活用。

Closes #7
Closes #17

## Test plan
- [x] \`npm run lint\` 通過
- [x] \`npm run test\` 106件通過
- [x] \`npm run build\` 成功
- [ ] ブラウザ動作確認（朝）

🤖 Generated with [Claude Code](https://claude.com/claude-code)