### PR TITLE
feat: アイテムシステム — 使用・装備・インベントリ画面 (#8)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -260,6 +260,26 @@ export function useGameLoop() {
     }
   }
 
+  // メッセージを出さずに1ターン経過させる（アイテム使用後など、呼び出し元で独自メッセージを出す場合）
+  function passTurn(): ActionResult {
+    if (!turnManager.isPlayerTurn)
+      return { messages: [], combatEvents: [], playerEvents: [], enemyEvents: [] }
+
+    turnManager.playerAction()
+    const enemyTurn = processEnemyTurn()
+    turnManager.enemyAction()
+    turnManager.endTurn()
+    store.endTurn()
+    store.decreaseSatiation(1)
+
+    return {
+      messages: enemyTurn.messages,
+      combatEvents: enemyTurn.events,
+      playerEvents: [],
+      enemyEvents: enemyTurn.events,
+    }
+  }
+
   function initFloor(floor: number) {
     const dungeonId = store.dungeon.dungeonId
     const dungeon = getDungeon(dungeonId)
@@ -324,6 +344,7 @@ export function useGameLoop() {
     playerMove,
     playerAttack,
     playerWait,
+    passTurn,
     initFloor,
     initDungeon,
     goNextFloor,

--- a/game/data/items.ts
+++ b/game/data/items.ts
@@ -1,9 +1,107 @@
+export type ItemType = 'weapon' | 'armor' | 'potion' | 'food' | 'other'
+
+export interface ItemEffect {
+  hp?: number
+  satiation?: number
+  attack?: number
+  defense?: number
+  cureStatus?: string[]
+}
+
 export interface ItemDef {
   id: string
   name: string
-  type: 'weapon' | 'potion' | 'other'
+  description: string
+  type: ItemType
+  effect?: ItemEffect
+  usable: boolean
+  equippable: boolean
 }
 
 export const ITEMS: Record<string, ItemDef> = {
-  sword: { id: 'sword', name: '剣', type: 'weapon' },
+  sword: {
+    id: 'sword',
+    name: '剣',
+    description: '攻撃力+5',
+    type: 'weapon',
+    effect: { attack: 5 },
+    usable: false,
+    equippable: true,
+  },
+  great_sword: {
+    id: 'great_sword',
+    name: '大剣',
+    description: '攻撃力+10',
+    type: 'weapon',
+    effect: { attack: 10 },
+    usable: false,
+    equippable: true,
+  },
+  shield: {
+    id: 'shield',
+    name: '盾',
+    description: '防御力+3',
+    type: 'armor',
+    effect: { defense: 3 },
+    usable: false,
+    equippable: true,
+  },
+  heavy_armor: {
+    id: 'heavy_armor',
+    name: '重装鎧',
+    description: '防御力+6',
+    type: 'armor',
+    effect: { defense: 6 },
+    usable: false,
+    equippable: true,
+  },
+  herb: {
+    id: 'herb',
+    name: '回復草',
+    description: 'HPを30回復',
+    type: 'potion',
+    effect: { hp: 30 },
+    usable: true,
+    equippable: false,
+  },
+  super_herb: {
+    id: 'super_herb',
+    name: '上薬草',
+    description: 'HPを60回復',
+    type: 'potion',
+    effect: { hp: 60 },
+    usable: true,
+    equippable: false,
+  },
+  antidote: {
+    id: 'antidote',
+    name: '毒消し草',
+    description: '毒を治療',
+    type: 'potion',
+    effect: { cureStatus: ['poison'] },
+    usable: true,
+    equippable: false,
+  },
+  bread: {
+    id: 'bread',
+    name: 'パン',
+    description: '満腹度を50回復',
+    type: 'food',
+    effect: { satiation: 50 },
+    usable: true,
+    equippable: false,
+  },
+  big_bread: {
+    id: 'big_bread',
+    name: '大きなパン',
+    description: '満腹度を100回復',
+    type: 'food',
+    effect: { satiation: 100 },
+    usable: true,
+    equippable: false,
+  },
+}
+
+export function getItem(id: string): ItemDef | undefined {
+  return ITEMS[id]
 }

--- a/game/dungeon/Abyss/F1.ts
+++ b/game/dungeon/Abyss/F1.ts
@@ -11,7 +11,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 1,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F2.ts
+++ b/game/dungeon/Abyss/F2.ts
@@ -11,7 +11,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+      { itemId: 'antidote', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F3.ts
+++ b/game/dungeon/Abyss/F3.ts
@@ -11,7 +11,14 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'bread', weight: 1 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F4.ts
+++ b/game/dungeon/Abyss/F4.ts
@@ -11,7 +11,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F5.ts
+++ b/game/dungeon/Abyss/F5.ts
@@ -11,7 +11,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+      { itemId: 'antidote', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F6.ts
+++ b/game/dungeon/Abyss/F6.ts
@@ -11,7 +11,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 2 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F7.ts
+++ b/game/dungeon/Abyss/F7.ts
@@ -11,7 +11,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 2 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F8.ts
+++ b/game/dungeon/Abyss/F8.ts
@@ -8,7 +8,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 4,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 2 },
+      { itemId: 'heavy_armor', weight: 2 },
+    ],
   },
 }
 

--- a/game/dungeon/Abyss/F9.ts
+++ b/game/dungeon/Abyss/F9.ts
@@ -8,7 +8,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 4,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 2 },
+      { itemId: 'heavy_armor', weight: 2 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F1.ts
+++ b/game/dungeon/DarkCastle/F1.ts
@@ -8,7 +8,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 1,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F2.ts
+++ b/game/dungeon/DarkCastle/F2.ts
@@ -8,7 +8,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 1,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+      { itemId: 'antidote', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F3.ts
+++ b/game/dungeon/DarkCastle/F3.ts
@@ -8,7 +8,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F4.ts
+++ b/game/dungeon/DarkCastle/F4.ts
@@ -11,7 +11,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'super_herb', weight: 1 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F5.ts
+++ b/game/dungeon/DarkCastle/F5.ts
@@ -11,7 +11,14 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 2 },
+      { itemId: 'super_herb', weight: 1 },
+      { itemId: 'bread', weight: 1 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F6.ts
+++ b/game/dungeon/DarkCastle/F6.ts
@@ -11,7 +11,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+      { itemId: 'antidote', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/DarkCastle/F7.ts
+++ b/game/dungeon/DarkCastle/F7.ts
@@ -11,7 +11,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 3,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'super_herb', weight: 2 },
+      { itemId: 'big_bread', weight: 1 },
+      { itemId: 'great_sword', weight: 1 },
+      { itemId: 'heavy_armor', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/SilentForest/F1.ts
+++ b/game/dungeon/SilentForest/F1.ts
@@ -8,7 +8,11 @@ const floor: FloorConfig = {
   },
   items: {
     count: 1,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/SilentForest/F2.ts
+++ b/game/dungeon/SilentForest/F2.ts
@@ -8,7 +8,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 1,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/SilentForest/F3.ts
+++ b/game/dungeon/SilentForest/F3.ts
@@ -8,7 +8,12 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+    ],
   },
 }
 

--- a/game/dungeon/SilentForest/F4.ts
+++ b/game/dungeon/SilentForest/F4.ts
@@ -8,7 +8,13 @@ const floor: FloorConfig = {
   },
   items: {
     count: 2,
-    types: [{ itemId: 'sword', weight: 1 }],
+    types: [
+      { itemId: 'herb', weight: 3 },
+      { itemId: 'bread', weight: 2 },
+      { itemId: 'sword', weight: 1 },
+      { itemId: 'shield', weight: 1 },
+      { itemId: 'antidote', weight: 1 },
+    ],
   },
 }
 

--- a/game/systems/ItemSystem.ts
+++ b/game/systems/ItemSystem.ts
@@ -1,0 +1,107 @@
+import { ITEMS, type ItemDef } from '../data/items'
+
+export interface PlayerLike {
+  hp: number
+  maxHp: number
+  satiation: number
+  maxSatiation: number
+  attack: number
+  defense: number
+}
+
+export interface UseResult {
+  success: boolean
+  message: string
+  consumed: boolean
+}
+
+export function useItem(itemDef: ItemDef, player: PlayerLike): UseResult {
+  if (!itemDef.usable) {
+    return { success: false, message: `${itemDef.name}は使用できない`, consumed: false }
+  }
+
+  const effect = itemDef.effect ?? {}
+  const messages: string[] = []
+
+  if (typeof effect.hp === 'number' && effect.hp > 0) {
+    const before = player.hp
+    player.hp = Math.min(player.maxHp, player.hp + effect.hp)
+    const gained = player.hp - before
+    if (gained > 0) {
+      messages.push(`HPが${gained}回復した`)
+    } else {
+      messages.push('HPは満タンだ')
+    }
+  }
+
+  if (typeof effect.satiation === 'number' && effect.satiation > 0) {
+    const before = player.satiation
+    player.satiation = Math.min(player.maxSatiation, player.satiation + effect.satiation)
+    const gained = player.satiation - before
+    if (gained > 0) {
+      messages.push(`満腹度が${gained}回復した`)
+    } else {
+      messages.push('満腹度は満タンだ')
+    }
+  }
+
+  if (effect.cureStatus && effect.cureStatus.length > 0) {
+    // 状態異常システム未実装のためメッセージのみ
+    messages.push('状態異常を治療した')
+  }
+
+  return {
+    success: true,
+    message: messages.length > 0 ? messages.join('、') : `${itemDef.name}を使った`,
+    consumed: true,
+  }
+}
+
+export interface EquipResult {
+  success: boolean
+  message: string
+  unequippedId: string | null
+  attackDelta: number
+  defenseDelta: number
+}
+
+export function equipItem(
+  itemDef: ItemDef,
+  currentEquippedId: string | null
+): EquipResult {
+  if (!itemDef.equippable) {
+    return {
+      success: false,
+      message: `${itemDef.name}は装備できない`,
+      unequippedId: null,
+      attackDelta: 0,
+      defenseDelta: 0,
+    }
+  }
+
+  const current = currentEquippedId ? ITEMS[currentEquippedId] : null
+  const currentAttack = current?.effect?.attack ?? 0
+  const currentDefense = current?.effect?.defense ?? 0
+  const newAttack = itemDef.effect?.attack ?? 0
+  const newDefense = itemDef.effect?.defense ?? 0
+
+  return {
+    success: true,
+    message: `${itemDef.name}を装備した`,
+    unequippedId: currentEquippedId,
+    attackDelta: newAttack - currentAttack,
+    defenseDelta: newDefense - currentDefense,
+  }
+}
+
+export function unequipItem(
+  itemDef: ItemDef
+): { attackDelta: number; defenseDelta: number; message: string } {
+  const attack = itemDef.effect?.attack ?? 0
+  const defense = itemDef.effect?.defense ?? 0
+  return {
+    attackDelta: attack === 0 ? 0 : -attack,
+    defenseDelta: defense === 0 ? 0 : -defense,
+    message: `${itemDef.name}を外した`,
+  }
+}

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -1,7 +1,16 @@
 import Phaser from 'phaser'
 import { TILE } from '../../game/data/maps'
 import { getDungeon } from '../../game/dungeon'
+import { ITEMS } from '../../game/data/items'
 import type { CombatEvent, ActionResult } from '../../composables/useGameLoop'
+
+const ITEM_TINT: Record<string, number> = {
+  weapon: 0xffffff,
+  armor: 0x66aaff,
+  potion: 0x66ff66,
+  food: 0xffcc66,
+  other: 0xcccccc,
+}
 
 export class DungeonScene extends Phaser.Scene {
   // 表示するタイル数（ビューポート）
@@ -472,6 +481,8 @@ export class DungeonScene extends Phaser.Scene {
       const y = this.offsetY + screenTileY * this.tileHeight + this.tileHeight / 2
       const sprite = this.add.image(x, y, 'weapon_sword')
       sprite.setScale(this.tileScale * 0.35)
+      const type = ITEMS[item.itemId]?.type ?? 'other'
+      sprite.setTint(ITEM_TINT[type] ?? 0xffffff)
       this.entityContainer.add(sprite)
     }
   }
@@ -544,6 +555,7 @@ export class DungeonScene extends Phaser.Scene {
       isConfirmOpen: () => boolean
       isMenuOpen: () => boolean
       isMinimapOpen: () => boolean
+      isInventoryOpen: () => boolean
       showConfirm: (message: string, onYes: () => void) => void
       toggleMenu: () => void
       moveMenuCursor: (dx: number, dy: number) => void
@@ -558,12 +570,25 @@ export class DungeonScene extends Phaser.Scene {
         exploredTiles: string[]
       ) => void
       hideMinimap: () => void
+      showInventory: (
+        inventory: { itemId: string; name: string; equipped?: boolean }[]
+      ) => void
+      hideInventory: () => void
+      refreshInventory: (
+        inventory: { itemId: string; name: string; equipped?: boolean }[]
+      ) => void
+      moveInventoryCursor: (dx: number, dy: number) => void
+      getInventorySelectedIndex: () => number
     }
   }
 
   private tryMove(dx: number, dy: number) {
     if (this.inputLocked) return
     const ui = this.getUiScene()
+    if (ui.isInventoryOpen()) {
+      ui.moveInventoryCursor(dx, dy)
+      return
+    }
     if (ui.isMenuOpen()) {
       ui.moveMenuCursor(dx, dy)
       return
@@ -616,6 +641,11 @@ export class DungeonScene extends Phaser.Scene {
       return
     }
 
+    if (ui.isInventoryOpen()) {
+      this.handleInventoryAction(action)
+      return
+    }
+
     if (ui.isMenuOpen()) {
       if (action === 'confirm') {
         const selected = ui.selectMenuItem()
@@ -629,6 +659,8 @@ export class DungeonScene extends Phaser.Scene {
               this.gameStore.floorItems.map((i: { x: number; y: number }) => ({ x: i.x, y: i.y })),
               this.gameStore.exploredTiles
             )
+          } else if (selected === '道具') {
+            ui.showInventory(this.gameStore.inventory)
           } else {
             this.updateUI([`${selected}（未実装）`])
           }
@@ -673,6 +705,52 @@ export class DungeonScene extends Phaser.Scene {
         this.updateUI(['次のアイテム（未実装）'])
         break
     }
+  }
+
+  private handleInventoryAction(action: string) {
+    const ui = this.getUiScene()
+    const index = ui.getInventorySelectedIndex()
+
+    if (action === 'inventory') {
+      ui.hideInventory()
+      return
+    }
+
+    if (action === 'confirm') {
+      const entry = this.gameStore.inventory[index]
+      if (!entry) return
+      const useResult = this.gameStore.useInventoryItem(index)
+      if (useResult.success) {
+        this.updateUI([useResult.message])
+        ui.refreshInventory(this.gameStore.inventory)
+        this.consumeTurnAfterItem()
+        return
+      }
+      const equipResult = this.gameStore.equipInventoryItem(index)
+      if (equipResult.success) {
+        this.updateUI([equipResult.message])
+        ui.refreshInventory(this.gameStore.inventory)
+        return
+      }
+      return
+    }
+
+    if (action === 'prevItem') {
+      const dropResult = this.gameStore.dropInventoryItem(index)
+      if (dropResult.success) {
+        this.updateUI([dropResult.message])
+        ui.refreshInventory(this.gameStore.inventory)
+      }
+      return
+    }
+  }
+
+  private consumeTurnAfterItem() {
+    // アイテム使用で1ターン消費（待機メッセージは出さない）
+    const result: ActionResult = this.gameLoop.passTurn()
+    this.drawScene()
+    this.updateUI(result.messages)
+    this.playSequencedCombatEffects(result)
   }
 
   // --- 戦闘演出 ---

--- a/phaser/scenes/UIScene.ts
+++ b/phaser/scenes/UIScene.ts
@@ -5,6 +5,7 @@ import { Controller } from '../ui/Controller'
 import { MenuOverlay } from '../ui/MenuOverlay'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { MinimapOverlay } from '../ui/MinimapOverlay'
+import { InventoryOverlay } from '../ui/InventoryOverlay'
 
 export class UIScene extends Phaser.Scene {
   private statusBar!: StatusBar
@@ -12,6 +13,7 @@ export class UIScene extends Phaser.Scene {
   private menu!: MenuOverlay
   private confirm!: ConfirmDialog
   private minimap!: MinimapOverlay
+  private inventory!: InventoryOverlay
 
   constructor() {
     super({ key: 'UIScene' })
@@ -28,6 +30,7 @@ export class UIScene extends Phaser.Scene {
     this.menu = new MenuOverlay(this)
     this.confirm = new ConfirmDialog(this)
     this.minimap = new MinimapOverlay(this)
+    this.inventory = new InventoryOverlay(this)
 
     // 初期メッセージ
     this.addMessage('ダンジョンに足を踏み入れた！')
@@ -113,6 +116,32 @@ export class UIScene extends Phaser.Scene {
 
   isMinimapOpen(): boolean {
     return this.minimap.isOpen()
+  }
+
+  // --- インベントリ ---
+
+  showInventory(inventory: { itemId: string; name: string; equipped?: boolean }[]) {
+    this.inventory.show(inventory)
+  }
+
+  hideInventory() {
+    this.inventory.hide()
+  }
+
+  refreshInventory(inventory: { itemId: string; name: string; equipped?: boolean }[]) {
+    this.inventory.refresh(inventory)
+  }
+
+  isInventoryOpen(): boolean {
+    return this.inventory.isOpen()
+  }
+
+  moveInventoryCursor(dx: number, dy: number) {
+    this.inventory.moveCursor(dx, dy)
+  }
+
+  getInventorySelectedIndex(): number {
+    return this.inventory.getSelectedIndex()
   }
 
   // --- イベント転送 ---

--- a/phaser/ui/InventoryOverlay.ts
+++ b/phaser/ui/InventoryOverlay.ts
@@ -1,0 +1,195 @@
+import type Phaser from 'phaser'
+import { TEXT_COLOR, UI_COLOR } from '../../game/data/colors'
+import { ITEMS } from '../../game/data/items'
+
+const BASE_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '14px',
+  color: TEXT_COLOR.white,
+  fontFamily: '"DotGothic16", monospace',
+  letterSpacing: 1,
+}
+
+interface InventoryEntry {
+  itemId: string
+  name: string
+  equipped?: boolean
+}
+
+export class InventoryOverlay {
+  private container: Phaser.GameObjects.Container
+  private visible = false
+  private cursorIndex = 0
+  private cursor: Phaser.GameObjects.Text
+  private rowTexts: Phaser.GameObjects.Text[] = []
+  private descText: Phaser.GameObjects.Text
+  private emptyText: Phaser.GameObjects.Text
+  private readonly maxRows = 8
+  private readonly rowStartY = 96
+  private readonly rowHeight = 26
+  private readonly rowStartX = 48
+
+  // 最新のインベントリ（スナップショット）
+  private entries: InventoryEntry[] = []
+
+  constructor(private scene: Phaser.Scene) {
+    this.container = scene.add.container(0, 0)
+    this.container.setVisible(false)
+    this.container.setDepth(550)
+
+    // 半透明背景
+    const overlay = scene.add.rectangle(240, 255, 480, 510, 0x000000, 0.75)
+    this.container.add(overlay)
+
+    // パネル
+    const panel = scene.add.graphics()
+    panel.fillStyle(UI_COLOR.panelBg, 0.95)
+    panel.fillRoundedRect(24, 56, 432, 380, 8)
+    panel.lineStyle(2, UI_COLOR.panelBorder, 1)
+    panel.strokeRoundedRect(24, 56, 432, 380, 8)
+    this.container.add(panel)
+
+    // タイトル
+    const title = scene.add.text(240, 72, 'どうぐ', {
+      ...BASE_STYLE,
+      fontSize: '18px',
+      fontStyle: 'bold',
+    })
+    title.setOrigin(0.5, 0.5)
+    this.container.add(title)
+
+    // アイテム行（空で事前配置、描画時に差し替え）
+    for (let i = 0; i < this.maxRows; i++) {
+      const y = this.rowStartY + i * this.rowHeight
+      const t = scene.add.text(this.rowStartX, y, '', BASE_STYLE)
+      this.container.add(t)
+      this.rowTexts.push(t)
+    }
+
+    // 空メッセージ
+    this.emptyText = scene.add.text(240, 180, '持ち物は空です', {
+      ...BASE_STYLE,
+      fontSize: '14px',
+      color: TEXT_COLOR.muted,
+    })
+    this.emptyText.setOrigin(0.5, 0.5)
+    this.emptyText.setVisible(false)
+    this.container.add(this.emptyText)
+
+    // 説明欄
+    const descBg = scene.add.graphics()
+    descBg.fillStyle(UI_COLOR.panelBg, 0.95)
+    descBg.fillRoundedRect(40, 336, 400, 52, 6)
+    descBg.lineStyle(1, UI_COLOR.panelBorder, 1)
+    descBg.strokeRoundedRect(40, 336, 400, 52, 6)
+    this.container.add(descBg)
+
+    this.descText = scene.add.text(52, 348, '', {
+      ...BASE_STYLE,
+      fontSize: '13px',
+      color: TEXT_COLOR.subtle,
+      wordWrap: { width: 380 },
+    })
+    this.container.add(this.descText)
+
+    // カーソル
+    this.cursor = scene.add.text(0, 0, '▶', {
+      ...BASE_STYLE,
+      fontSize: '13px',
+      color: TEXT_COLOR.white,
+    })
+    this.container.add(this.cursor)
+
+    // 操作ヒント
+    const hint = scene.add.text(240, 408, 'A:使う/装備  L:捨てる  B:閉じる', {
+      ...BASE_STYLE,
+      fontSize: '11px',
+      color: TEXT_COLOR.dim,
+    })
+    hint.setOrigin(0.5, 0.5)
+    this.container.add(hint)
+  }
+
+  show(inventory: InventoryEntry[]) {
+    this.entries = inventory
+    this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, inventory.length - 1))
+    this.visible = true
+    this.refresh()
+    this.container.setVisible(true)
+  }
+
+  hide() {
+    this.visible = false
+    this.container.setVisible(false)
+  }
+
+  isOpen(): boolean {
+    return this.visible
+  }
+
+  refresh(inventory?: InventoryEntry[]) {
+    if (inventory) this.entries = inventory
+    const items = this.entries
+    const hasItems = items.length > 0
+    this.emptyText.setVisible(!hasItems)
+
+    for (let i = 0; i < this.maxRows; i++) {
+      const entry = items[i]
+      const t = this.rowTexts[i]
+      if (!entry) {
+        t.setText('')
+        continue
+      }
+      const equippedMark = entry.equipped ? 'E ' : '  '
+      t.setText(`${equippedMark}${entry.name}`)
+    }
+
+    if (hasItems) {
+      this.cursorIndex = Math.min(this.cursorIndex, items.length - 1)
+      this.updateCursor()
+      this.updateDescription()
+    } else {
+      this.cursor.setVisible(false)
+      this.descText.setText('')
+    }
+  }
+
+  moveCursor(_dx: number, dy: number) {
+    if (!this.visible || this.entries.length === 0) return
+    const len = this.entries.length
+    this.cursorIndex = (this.cursorIndex + dy + len) % len
+    this.updateCursor()
+    this.updateDescription()
+  }
+
+  getSelectedIndex(): number {
+    return this.cursorIndex
+  }
+
+  getSelectedEntry(): InventoryEntry | null {
+    return this.entries[this.cursorIndex] ?? null
+  }
+
+  private updateCursor() {
+    if (this.entries.length === 0) {
+      this.cursor.setVisible(false)
+      return
+    }
+    this.cursor.setVisible(true)
+    const y = this.rowStartY + this.cursorIndex * this.rowHeight
+    this.cursor.setPosition(this.rowStartX - 18, y)
+  }
+
+  private updateDescription() {
+    const entry = this.entries[this.cursorIndex]
+    if (!entry) {
+      this.descText.setText('')
+      return
+    }
+    const def = ITEMS[entry.itemId]
+    if (!def) {
+      this.descText.setText(entry.name)
+      return
+    }
+    this.descText.setText(`${def.name}：${def.description}`)
+  }
+}

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -1,4 +1,10 @@
 import { defineStore } from 'pinia'
+import { ITEMS } from '~/game/data/items'
+import {
+  useItem as applyUseItem,
+  equipItem as calcEquip,
+  unequipItem as calcUnequip,
+} from '~/game/systems/ItemSystem'
 
 interface PlayerState {
   hp: number
@@ -36,6 +42,7 @@ interface FloorItem {
 interface InventoryItem {
   itemId: string
   name: string
+  equipped?: boolean
 }
 
 interface DungeonState {
@@ -204,6 +211,67 @@ export const useGameStore = defineStore('game', {
 
     clearFloorItems() {
       this.floorItems = []
+    },
+
+    useInventoryItem(index: number): { success: boolean; message: string } {
+      const entry = this.inventory[index]
+      if (!entry) return { success: false, message: '' }
+      const def = ITEMS[entry.itemId]
+      if (!def) return { success: false, message: '' }
+      const result = applyUseItem(def, this.player)
+      if (result.consumed) {
+        this.inventory.splice(index, 1)
+      }
+      return { success: result.success, message: result.message }
+    },
+
+    equipInventoryItem(index: number): { success: boolean; message: string } {
+      const entry = this.inventory[index]
+      if (!entry) return { success: false, message: '' }
+      const def = ITEMS[entry.itemId]
+      if (!def) return { success: false, message: '' }
+
+      // 既に装備済みなら外す
+      if (entry.equipped) {
+        const unequipped = calcUnequip(def)
+        this.player.attack += unequipped.attackDelta
+        this.player.defense += unequipped.defenseDelta
+        entry.equipped = false
+        return { success: true, message: unequipped.message }
+      }
+
+      // 同タイプの装備中アイテムを検索（1スロット1装備）
+      const currentIndex = this.inventory.findIndex(
+        (i, idx) => idx !== index && i.equipped && ITEMS[i.itemId]?.type === def.type
+      )
+      const currentId = currentIndex >= 0 ? this.inventory[currentIndex].itemId : null
+      const result = calcEquip(def, currentId)
+      if (!result.success) {
+        return { success: false, message: result.message }
+      }
+      if (currentIndex >= 0) {
+        this.inventory[currentIndex].equipped = false
+      }
+      this.player.attack += result.attackDelta
+      this.player.defense += result.defenseDelta
+      entry.equipped = true
+      return { success: true, message: result.message }
+    },
+
+    dropInventoryItem(index: number): { success: boolean; message: string; itemId: string | null } {
+      const entry = this.inventory[index]
+      if (!entry) return { success: false, message: '', itemId: null }
+      const def = ITEMS[entry.itemId]
+      // 装備中なら先に外す
+      if (entry.equipped && def) {
+        const u = calcUnequip(def)
+        this.player.attack += u.attackDelta
+        this.player.defense += u.defenseDelta
+      }
+      const name = entry.name
+      const itemId = entry.itemId
+      this.inventory.splice(index, 1)
+      return { success: true, message: `${name}を捨てた`, itemId }
     },
 
     setCurrentMap(map: number[][]) {

--- a/tests/unit/systems/ItemSystem.test.ts
+++ b/tests/unit/systems/ItemSystem.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { useItem, equipItem, unequipItem } from '../../../game/systems/ItemSystem'
+import { ITEMS } from '../../../game/data/items'
+
+function makePlayer(overrides: Partial<{ hp: number; maxHp: number; satiation: number; maxSatiation: number; attack: number; defense: number }> = {}) {
+  return {
+    hp: 50,
+    maxHp: 100,
+    satiation: 50,
+    maxSatiation: 100,
+    attack: 10,
+    defense: 5,
+    ...overrides,
+  }
+}
+
+describe('ItemSystem.useItem', () => {
+  it('herb は HP を30回復する', () => {
+    const player = makePlayer({ hp: 50 })
+    const result = useItem(ITEMS.herb, player)
+    expect(result.success).toBe(true)
+    expect(result.consumed).toBe(true)
+    expect(player.hp).toBe(80)
+    expect(result.message).toContain('30')
+  })
+
+  it('HP が最大値を超えない', () => {
+    const player = makePlayer({ hp: 90, maxHp: 100 })
+    useItem(ITEMS.herb, player)
+    expect(player.hp).toBe(100)
+  })
+
+  it('HP 満タンでは回復量0のメッセージ', () => {
+    const player = makePlayer({ hp: 100, maxHp: 100 })
+    const result = useItem(ITEMS.herb, player)
+    expect(player.hp).toBe(100)
+    expect(result.message).toContain('満タン')
+  })
+
+  it('bread は満腹度を回復する', () => {
+    const player = makePlayer({ satiation: 30, maxSatiation: 100 })
+    useItem(ITEMS.bread, player)
+    expect(player.satiation).toBe(80)
+  })
+
+  it('装備は使用できない', () => {
+    const player = makePlayer()
+    const result = useItem(ITEMS.sword, player)
+    expect(result.success).toBe(false)
+    expect(result.consumed).toBe(false)
+  })
+
+  it('antidote は消費扱いでメッセージが出る', () => {
+    const player = makePlayer()
+    const result = useItem(ITEMS.antidote, player)
+    expect(result.success).toBe(true)
+    expect(result.consumed).toBe(true)
+  })
+})
+
+describe('ItemSystem.equipItem', () => {
+  it('sword で攻撃+5', () => {
+    const result = equipItem(ITEMS.sword, null)
+    expect(result.success).toBe(true)
+    expect(result.attackDelta).toBe(5)
+    expect(result.defenseDelta).toBe(0)
+    expect(result.unequippedId).toBeNull()
+  })
+
+  it('sword → great_sword に変更すると差分が +5 になる', () => {
+    const result = equipItem(ITEMS.great_sword, 'sword')
+    expect(result.success).toBe(true)
+    expect(result.attackDelta).toBe(5)
+    expect(result.unequippedId).toBe('sword')
+  })
+
+  it('shield で防御+3', () => {
+    const result = equipItem(ITEMS.shield, null)
+    expect(result.success).toBe(true)
+    expect(result.defenseDelta).toBe(3)
+    expect(result.attackDelta).toBe(0)
+  })
+
+  it('ポーションは装備できない', () => {
+    const result = equipItem(ITEMS.herb, null)
+    expect(result.success).toBe(false)
+    expect(result.attackDelta).toBe(0)
+    expect(result.defenseDelta).toBe(0)
+  })
+})
+
+describe('ItemSystem.unequipItem', () => {
+  it('装備を外すと差分はマイナス', () => {
+    const result = unequipItem(ITEMS.sword)
+    expect(result.attackDelta).toBe(-5)
+    expect(result.defenseDelta).toBe(0)
+  })
+
+  it('shield を外すと防御-3', () => {
+    const result = unequipItem(ITEMS.shield)
+    expect(result.defenseDelta).toBe(-3)
+  })
+})
+
+describe('ITEMS データ整合性', () => {
+  it('全アイテムが id/name/type を持つ', () => {
+    for (const [id, def] of Object.entries(ITEMS)) {
+      expect(def.id).toBe(id)
+      expect(def.name).toBeTruthy()
+      expect(def.type).toBeTruthy()
+    }
+  })
+
+  it('装備可能な武器/防具は equippable=true', () => {
+    for (const def of Object.values(ITEMS)) {
+      if (def.type === 'weapon' || def.type === 'armor') {
+        expect(def.equippable).toBe(true)
+      }
+    }
+  })
+
+  it('ポーション・食料は usable=true', () => {
+    for (const def of Object.values(ITEMS)) {
+      if (def.type === 'potion' || def.type === 'food') {
+        expect(def.usable).toBe(true)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- 武器・防具・薬草・食料 9種のアイテム定義
- アイテム使用（HP回復/満腹回復）・装備（攻撃力/防御力変動）・捨てる操作
- インベントリ画面（カーソル選択・装備マーク・説明欄）
- 床アイテムのタイプ別ティント
- 全ダンジョンのフロアitemTypes多様化

## アイテム一覧

| ID | 名前 | 種別 | 効果 |
|----|------|------|------|
| sword | 剣 | 武器 | 攻+5 |
| great_sword | 大剣 | 武器 | 攻+10 |
| shield | 盾 | 防具 | 防+3 |
| heavy_armor | 重装鎧 | 防具 | 防+6 |
| herb | 回復草 | 薬 | HP+30 |
| super_herb | 上薬草 | 薬 | HP+60 |
| antidote | 毒消し草 | 薬 | 状態異常治療（システム未実装） |
| bread | パン | 食料 | 満+50 |
| big_bread | 大きなパン | 食料 | 満+100 |

## 設計メモ
- \`game/systems/ItemSystem.ts\` は純粋関数で Phaser/Pinia に依存しない → テスト可
- 装備は同タイプ1スロット（武器1・防具1）で自動入れ替え
- アイテム使用時のみ1ターン消費、装備/捨ては0ターン

## 操作
- メニュー(B/SELECT) → 道具 → インベントリ画面
- 十字キー上下: カーソル移動
- A: 使う or 装備（アイテム種別で自動判定）
- L: 捨てる
- B: 閉じる

Closes #8

## Test plan
- [x] \`npm run lint\` 通過
- [x] \`npm run test\` 121件通過（+15件）
- [x] \`npm run build\` 成功
- [ ] ブラウザ動作確認（朝）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **New Features**
  * コンバットに「パス」アクション追加：ターンを消費して何もしない選択が可能に
  * 道具インベントリシステム実装：所持アイテムの確認・使用・装備・破棄が可能
  * 道具効果システム：HP回復、満腹度回復、攻防力上昇などのステータス効果が機能
  * ダンジョン内のドロップアイテム多様化：全フロアで草・パン・武器・防具・薬など種類豊富なアイテムを獲得可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->