### PR TITLE
feat: ゴールド・装備データモデル拡張 (#33)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -2,7 +2,6 @@ import { useGameStore } from '~/stores/gameStore'
 import { TurnManager } from '~/game/systems/TurnManager'
 import { CombatSystem } from '~/game/systems/CombatSystem'
 import { decideAction } from '~/game/systems/EnemyAI'
-import { ITEMS } from '~/game/data/items'
 import { generateFloor } from '~/game/systems/DungeonGenerator'
 import { getFloorDifficulty } from '~/game/data/floorConfig'
 import { getDungeon, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
@@ -217,10 +216,11 @@ export function useGameLoop() {
 
     const item = store.floorItems.find((i) => i.x === newX && i.y === newY)
     if (item) {
-      const def = ITEMS[item.itemId]
-      store.addToInventory({ itemId: item.itemId, name: def.name })
+      const pickup = store.pickupItem(item.itemId)
       store.removeFloorItem(item.id)
-      messages.push(`${def.name}を拾った！`)
+      if (pickup.message) {
+        messages.push(pickup.message)
+      }
     }
 
     turnManager.playerAction()

--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -12,7 +12,8 @@
     "maxHealth": 100,
     "attack": 10,
     "defense": 5,
-    "viewRange": 6
+    "viewRange": 6,
+    "initialGold": 0
   },
   "enemyTypes": {
     "skeleton": {
@@ -28,13 +29,20 @@
       "exp": 20
     }
   },
-  "itemTypes": {
-    "healingGrass": {
-      "healAmount": 30
-    },
-    "antidoteGrass": {
-      "curePoison": true
-    }
+  "itemConfig": {
+    "inventoryMaxSlots": 20,
+    "maxStackSize": 99
+  },
+  "equipmentConfig": {
+    "maxEnhanceLevel": 9,
+    "enhanceBonusPerLevel": 1,
+    "enhanceCostBase": 100,
+    "enhanceCostMultiplier": 1.5
+  },
+  "goldConfig": {
+    "defaultDropAmount": 10,
+    "dropVariance": 5,
+    "dropChance": 0.3
   },
   "dungeonConfig": {
     "floorsTotal": 10,

--- a/game/data/items.ts
+++ b/game/data/items.ts
@@ -1,4 +1,4 @@
-export type ItemType = 'weapon' | 'armor' | 'potion' | 'food' | 'other'
+export type ItemType = 'weapon' | 'armor' | 'potion' | 'food' | 'scroll' | 'gold' | 'special' | 'other'
 
 export interface ItemEffect {
   hp?: number
@@ -6,6 +6,7 @@ export interface ItemEffect {
   attack?: number
   defense?: number
   cureStatus?: string[]
+  scrollAction?: 'teleport' | 'revealMap' | 'escape'
 }
 
 export interface ItemDef {
@@ -16,6 +17,46 @@ export interface ItemDef {
   effect?: ItemEffect
   usable: boolean
   equippable: boolean
+  stackable?: boolean // 重ねて所持可能（ポーション・食料・スクロール・ゴールド）
+}
+
+export interface EquipmentData {
+  baseItemId: string
+  enhanceLevel: number
+  attackBonus: number
+  defenseBonus: number
+}
+
+export function computeEquipmentStats(
+  baseItem: ItemDef,
+  enhanceLevel: number,
+  enhanceBonusPerLevel: number
+): { attackBonus: number; defenseBonus: number } {
+  const baseAttack = baseItem.effect?.attack ?? 0
+  const baseDefense = baseItem.effect?.defense ?? 0
+  const enhance = Math.max(0, enhanceLevel) * enhanceBonusPerLevel
+  return {
+    attackBonus: baseAttack + (baseAttack > 0 ? enhance : 0),
+    defenseBonus: baseDefense + (baseDefense > 0 ? enhance : 0),
+  }
+}
+
+export function makeEquipmentData(
+  baseItem: ItemDef,
+  enhanceLevel: number = 0,
+  enhanceBonusPerLevel: number = 1
+): EquipmentData {
+  const { attackBonus, defenseBonus } = computeEquipmentStats(
+    baseItem,
+    enhanceLevel,
+    enhanceBonusPerLevel
+  )
+  return {
+    baseItemId: baseItem.id,
+    enhanceLevel,
+    attackBonus,
+    defenseBonus,
+  }
 }
 
 export const ITEMS: Record<string, ItemDef> = {
@@ -63,6 +104,7 @@ export const ITEMS: Record<string, ItemDef> = {
     effect: { hp: 30 },
     usable: true,
     equippable: false,
+    stackable: true,
   },
   super_herb: {
     id: 'super_herb',
@@ -72,6 +114,7 @@ export const ITEMS: Record<string, ItemDef> = {
     effect: { hp: 60 },
     usable: true,
     equippable: false,
+    stackable: true,
   },
   antidote: {
     id: 'antidote',
@@ -81,6 +124,7 @@ export const ITEMS: Record<string, ItemDef> = {
     effect: { cureStatus: ['poison'] },
     usable: true,
     equippable: false,
+    stackable: true,
   },
   bread: {
     id: 'bread',
@@ -90,6 +134,7 @@ export const ITEMS: Record<string, ItemDef> = {
     effect: { satiation: 50 },
     usable: true,
     equippable: false,
+    stackable: true,
   },
   big_bread: {
     id: 'big_bread',
@@ -99,6 +144,45 @@ export const ITEMS: Record<string, ItemDef> = {
     effect: { satiation: 100 },
     usable: true,
     equippable: false,
+    stackable: true,
+  },
+  scroll_escape: {
+    id: 'scroll_escape',
+    name: 'リレミトの巻物',
+    description: 'ダンジョンから脱出する',
+    type: 'scroll',
+    effect: { scrollAction: 'escape' },
+    usable: true,
+    equippable: false,
+    stackable: true,
+  },
+  scroll_map: {
+    id: 'scroll_map',
+    name: '地形の巻物',
+    description: 'フロア全体の地形を表示',
+    type: 'scroll',
+    effect: { scrollAction: 'revealMap' },
+    usable: true,
+    equippable: false,
+    stackable: true,
+  },
+  gold: {
+    id: 'gold',
+    name: 'ゴールド',
+    description: '通貨',
+    type: 'gold',
+    usable: false,
+    equippable: false,
+    stackable: true,
+  },
+  strange_safe: {
+    id: 'strange_safe',
+    name: '謎の金庫',
+    description: '中身は鑑定しないとわからない',
+    type: 'special',
+    usable: false,
+    equippable: false,
+    stackable: false,
   },
 }
 

--- a/phaser/ui/InventoryOverlay.ts
+++ b/phaser/ui/InventoryOverlay.ts
@@ -13,6 +13,8 @@ interface InventoryEntry {
   itemId: string
   name: string
   equipped?: boolean
+  stack?: number
+  equipmentData?: { enhanceLevel: number }
 }
 
 export class InventoryOverlay {
@@ -140,7 +142,12 @@ export class InventoryOverlay {
         continue
       }
       const equippedMark = entry.equipped ? 'E ' : '  '
-      t.setText(`${equippedMark}${entry.name}`)
+      const enhanceText =
+        entry.equipmentData && entry.equipmentData.enhanceLevel > 0
+          ? ` +${entry.equipmentData.enhanceLevel}`
+          : ''
+      const stackText = entry.stack && entry.stack > 1 ? ` x${entry.stack}` : ''
+      t.setText(`${equippedMark}${entry.name}${enhanceText}${stackText}`)
     }
 
     if (hasItems) {

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -1,10 +1,11 @@
 import { defineStore } from 'pinia'
-import { ITEMS } from '~/game/data/items'
+import { ITEMS, type EquipmentData } from '~/game/data/items'
 import {
   useItem as applyUseItem,
   equipItem as calcEquip,
   unequipItem as calcUnequip,
 } from '~/game/systems/ItemSystem'
+import gameConfig from '~/game/data/gameConfig.json'
 
 interface PlayerState {
   hp: number
@@ -15,6 +16,7 @@ interface PlayerState {
   maxSatiation: number
   attack: number
   defense: number
+  gold: number
   direction: { dx: number; dy: number }
   position: { x: number; y: number }
 }
@@ -43,6 +45,8 @@ interface InventoryItem {
   itemId: string
   name: string
   equipped?: boolean
+  stack?: number
+  equipmentData?: EquipmentData
 }
 
 interface DungeonState {
@@ -79,6 +83,7 @@ export const useGameStore = defineStore('game', {
       maxSatiation: 100,
       attack: 10,
       defense: 5,
+      gold: 0,
       direction: { dx: 0, dy: 1 },
       position: { x: 7, y: 7 },
     },
@@ -209,6 +214,38 @@ export const useGameStore = defineStore('game', {
       this.inventory.push(item)
     },
 
+    pickupItem(itemId: string, amount: number = 1): { message: string; toGold: boolean } {
+      const def = ITEMS[itemId]
+      if (!def) return { message: '', toGold: false }
+
+      // ゴールドはプレイヤーの所持金に加算
+      if (def.type === 'gold') {
+        const goldAmount =
+          amount > 1 ? amount : gameConfig.goldConfig?.defaultDropAmount ?? 10
+        this.player.gold += goldAmount
+        return { message: `${goldAmount}Gを拾った！`, toGold: true }
+      }
+
+      // スタック可能アイテムは既存スタックに合算
+      if (def.stackable) {
+        const existing = this.inventory.find(
+          (i) => i.itemId === itemId && !i.equipped
+        )
+        if (existing) {
+          existing.stack = (existing.stack ?? 1) + amount
+          return { message: `${def.name}を拾った！`, toGold: false }
+        }
+      }
+
+      // それ以外は新規スロット
+      const entry: InventoryItem = { itemId, name: def.name }
+      if (def.stackable) {
+        entry.stack = amount
+      }
+      this.inventory.push(entry)
+      return { message: `${def.name}を拾った！`, toGold: false }
+    },
+
     clearFloorItems() {
       this.floorItems = []
     },
@@ -220,7 +257,12 @@ export const useGameStore = defineStore('game', {
       if (!def) return { success: false, message: '' }
       const result = applyUseItem(def, this.player)
       if (result.consumed) {
-        this.inventory.splice(index, 1)
+        const currentStack = entry.stack ?? 1
+        if (currentStack > 1) {
+          entry.stack = currentStack - 1
+        } else {
+          this.inventory.splice(index, 1)
+        }
       }
       return { success: result.success, message: result.message }
     },

--- a/tests/unit/systems/ItemSystem.test.ts
+++ b/tests/unit/systems/ItemSystem.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { useItem, equipItem, unequipItem } from '../../../game/systems/ItemSystem'
-import { ITEMS } from '../../../game/data/items'
+import {
+  ITEMS,
+  computeEquipmentStats,
+  makeEquipmentData,
+} from '../../../game/data/items'
 
 function makePlayer(overrides: Partial<{ hp: number; maxHp: number; satiation: number; maxSatiation: number; attack: number; defense: number }> = {}) {
   return {
@@ -125,5 +129,56 @@ describe('ITEMS データ整合性', () => {
         expect(def.usable).toBe(true)
       }
     }
+  })
+
+  it('scroll/gold/special タイプのアイテムが存在する', () => {
+    const types = Object.values(ITEMS).map((i) => i.type)
+    expect(types).toContain('scroll')
+    expect(types).toContain('gold')
+    expect(types).toContain('special')
+  })
+
+  it('ポーション・食料・スクロール・ゴールドは stackable=true', () => {
+    for (const def of Object.values(ITEMS)) {
+      if (['potion', 'food', 'scroll', 'gold'].includes(def.type)) {
+        expect(def.stackable).toBe(true)
+      }
+    }
+  })
+})
+
+describe('EquipmentData', () => {
+  it('未強化（+0）は ベース値そのまま', () => {
+    const stats = computeEquipmentStats(ITEMS.sword, 0, 1)
+    expect(stats.attackBonus).toBe(5)
+    expect(stats.defenseBonus).toBe(0)
+  })
+
+  it('強化+3で 攻撃が+3上乗せ', () => {
+    const stats = computeEquipmentStats(ITEMS.sword, 3, 1)
+    expect(stats.attackBonus).toBe(8)
+  })
+
+  it('盾の+2で 防御が+2上乗せ', () => {
+    const stats = computeEquipmentStats(ITEMS.shield, 2, 1)
+    expect(stats.defenseBonus).toBe(5)
+  })
+
+  it('attack が0の防具は強化してもattackに加算されない', () => {
+    const stats = computeEquipmentStats(ITEMS.shield, 5, 1)
+    expect(stats.attackBonus).toBe(0)
+  })
+
+  it('makeEquipmentData で完全なデータが作れる', () => {
+    const data = makeEquipmentData(ITEMS.great_sword, 2, 1)
+    expect(data.baseItemId).toBe('great_sword')
+    expect(data.enhanceLevel).toBe(2)
+    expect(data.attackBonus).toBe(12)
+    expect(data.defenseBonus).toBe(0)
+  })
+
+  it('負の強化レベルは0扱い', () => {
+    const stats = computeEquipmentStats(ITEMS.sword, -1, 1)
+    expect(stats.attackBonus).toBe(5)
   })
 })


### PR DESCRIPTION
## Summary
I-1相当のデータモデル拡張。後続 I-2〜I-4 の下地。

## 変更
- \`ItemType\` に \`scroll\` / \`gold\` / \`special\` を追加
- \`ItemDef.stackable\` フラグ導入 — ポーション・食料・巻物・ゴールドはスタック可
- \`EquipmentData\` インターフェース新設（baseItemId, enhanceLevel, attackBonus, defenseBonus）
- \`computeEquipmentStats\` / \`makeEquipmentData\` — 純粋関数で強化値計算
- \`InventoryItem\` に \`stack\` / \`equipmentData\` フィールド追加
- \`player.gold\` 追加
- \`pickupItem\` アクション — gold/stackable/通常を自動振り分け
- \`gameConfig.json\` に equipmentConfig / goldConfig / itemConfig セクション追加
- InventoryOverlay でスタック数（\`x3\`）・強化値（\`+2\`）を表示
- 新規アイテム定義: \`scroll_escape\`, \`scroll_map\`, \`gold\`, \`strange_safe\`
  （使用ロジックは I-4/I-5 で実装）

## 設計メモ
- アイテムデータ型は \`game/data/items.ts\` に集約（Phaser非依存）
- 装備強化は \`enhanceLevel × enhanceBonusPerLevel\` を baseAttack/baseDefense に加算
- 攻撃=0の防具は強化してもattackに加算されない（安全策）
- スタック可能アイテムは \`addToInventory\` ではなく \`pickupItem\` から投入
- \`pickupItem\` の gold 加算量は引数 \`amount\` 優先、省略時は gameConfig.goldConfig.defaultDropAmount

## 後続タスクへの影響
- I-2 ゴールドシステム: \`player.gold\` を StatusBar/MenuOverlay に表示、敵ドロップ処理追加
- I-3 装備強化: \`equipmentData\` を使って+N表示・強化コスト計算
- I-4 特殊アイテム: \`scroll_escape\` / \`strange_safe\` の使用ロジック実装

Closes #33

## Test plan
- [x] \`npm run lint\` 通過
- [x] \`npm run test\` 129件通過（+8件）
- [x] \`npm run build\` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)