### PR TITLE
feat: デバッグモード（コナミコマンド起動・管理者用機能）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
+    # Chromium + system deps が同梱された公式イメージを使い、playwright install をスキップする
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -49,7 +53,6 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4
         if: always()

--- a/components/DebugPanel.client.vue
+++ b/components/DebugPanel.client.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref } from 'vue'
+  import { computed, reactive, ref, watch } from 'vue'
   import { useGameStore } from '~/stores/gameStore'
   import { useGameLoop } from '~/composables/useGameLoop'
   import { useDebugMode } from '~/composables/useDebugMode'
@@ -19,6 +19,114 @@
     }))
   )
 
+  const playerDraft = reactive({
+    hp: 0,
+    maxHp: 0,
+    attack: 0,
+    defense: 0,
+    dodgePct: 0,
+    level: 1,
+    exp: 0,
+    satiation: 0,
+    maxSatiation: 0,
+    posX: 0,
+    posY: 0,
+  })
+
+  function syncPlayerDraft() {
+    playerDraft.hp = store.player.hp
+    playerDraft.maxHp = store.player.maxHp
+    playerDraft.attack = store.player.attack
+    playerDraft.defense = store.player.defense
+    playerDraft.dodgePct = Math.round((store.player.dodge ?? 0) * 1000) / 10
+    playerDraft.level = store.player.level
+    playerDraft.exp = store.player.exp
+    playerDraft.satiation = store.player.satiation
+    playerDraft.maxSatiation = store.player.maxSatiation
+    playerDraft.posX = store.player.position.x
+    playerDraft.posY = store.player.position.y
+  }
+
+  function savePlayer() {
+    store.setPlayerStats({
+      hp: playerDraft.hp,
+      maxHp: playerDraft.maxHp,
+      attack: playerDraft.attack,
+      defense: playerDraft.defense,
+      dodge: Math.max(0, Math.min(100, playerDraft.dodgePct)) / 100,
+      level: playerDraft.level,
+      exp: playerDraft.exp,
+      satiation: playerDraft.satiation,
+      maxSatiation: playerDraft.maxSatiation,
+      position: { x: playerDraft.posX, y: playerDraft.posY },
+    })
+    store.addMessage('[DEBUG] プレイヤーを保存')
+  }
+
+  interface EnemyDraft {
+    hp: number
+    attack: number
+    defense: number
+    dodgePct: number
+  }
+  const enemyDrafts = reactive<Record<string, EnemyDraft>>({})
+
+  function enemyToDraft(e: { hp: number; attack: number; defense: number; dodge?: number }): EnemyDraft {
+    return {
+      hp: e.hp,
+      attack: e.attack,
+      defense: e.defense,
+      dodgePct: Math.round((e.dodge ?? 0) * 1000) / 10,
+    }
+  }
+
+  function syncEnemyDrafts() {
+    for (const e of store.enemies) {
+      if (!enemyDrafts[e.id]) {
+        enemyDrafts[e.id] = enemyToDraft(e)
+      }
+    }
+    for (const id of Object.keys(enemyDrafts)) {
+      if (!store.enemies.some((e) => e.id === id)) {
+        Reflect.deleteProperty(enemyDrafts, id)
+      }
+    }
+  }
+
+  function resetEnemyDraft(id: string) {
+    const e = store.enemies.find((e) => e.id === id)
+    if (!e) return
+    enemyDrafts[id] = enemyToDraft(e)
+  }
+
+  function saveEnemy(id: string) {
+    const draft = enemyDrafts[id]
+    if (!draft) return
+    store.setEnemyStats(id, {
+      hp: draft.hp,
+      attack: draft.attack,
+      defense: draft.defense,
+      dodge: Math.max(0, Math.min(100, draft.dodgePct)) / 100,
+    })
+    store.addMessage('[DEBUG] 敵を保存')
+  }
+
+  watch(
+    () => debug.enabled.value,
+    (v) => {
+      if (v) {
+        syncPlayerDraft()
+        syncEnemyDrafts()
+      }
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () => store.enemies.map((e) => e.id).join(','),
+    () => syncEnemyDrafts()
+  )
+
   const jumpDungeonId = ref(store.dungeon.dungeonId)
   const jumpFloor = ref(store.dungeon.floor)
 
@@ -27,6 +135,8 @@
     const floor = Math.max(1, Math.min(jumpFloor.value, def.floors.length))
     store.setDungeonState(jumpDungeonId.value, def.floors.length, floor)
     gameLoop.initFloor(floor)
+    syncPlayerDraft()
+    syncEnemyDrafts()
     store.addMessage(`[DEBUG] ${def.name} ${floor}Fへジャンプ`)
   }
 
@@ -38,6 +148,7 @@
 
   function fullHeal() {
     store.setPlayerStats({ hp: store.player.maxHp, satiation: store.player.maxSatiation })
+    syncPlayerDraft()
     store.addMessage('[DEBUG] HP・満腹度を全回復')
   }
 
@@ -59,36 +170,53 @@
 
     <div v-if="!collapsed" class="body">
       <section class="section">
-        <h3>Player</h3>
+        <div class="section-header">
+          <h3>Player</h3>
+          <div class="actions">
+            <button
+              class="btn-xs"
+              type="button"
+              title="現在の値を再読込"
+              @click="syncPlayerDraft"
+            >
+              ↻
+            </button>
+            <button class="btn-sm primary" type="button" @click="savePlayer">保存</button>
+          </div>
+        </div>
         <div class="row">
           <label>HP</label>
-          <input v-model.number="store.player.hp" type="number" min="0" >
+          <input v-model.number="playerDraft.hp" type="number" min="0" >
           <label>/ Max</label>
-          <input v-model.number="store.player.maxHp" type="number" min="1" >
+          <input v-model.number="playerDraft.maxHp" type="number" min="1" >
         </div>
         <div class="row">
           <label>ATK</label>
-          <input v-model.number="store.player.attack" type="number" min="0" >
+          <input v-model.number="playerDraft.attack" type="number" min="0" >
           <label>DEF</label>
-          <input v-model.number="store.player.defense" type="number" min="0" >
+          <input v-model.number="playerDraft.defense" type="number" min="0" >
+        </div>
+        <div class="row">
+          <label>回避%</label>
+          <input v-model.number="playerDraft.dodgePct" type="number" min="0" max="100" step="0.5" >
         </div>
         <div class="row">
           <label>Lv</label>
-          <input v-model.number="store.player.level" type="number" min="1" >
+          <input v-model.number="playerDraft.level" type="number" min="1" >
           <label>EXP</label>
-          <input v-model.number="store.player.exp" type="number" min="0" >
+          <input v-model.number="playerDraft.exp" type="number" min="0" >
         </div>
         <div class="row">
           <label>満腹</label>
-          <input v-model.number="store.player.satiation" type="number" min="0" >
+          <input v-model.number="playerDraft.satiation" type="number" min="0" >
           <label>/ Max</label>
-          <input v-model.number="store.player.maxSatiation" type="number" min="1" >
+          <input v-model.number="playerDraft.maxSatiation" type="number" min="1" >
         </div>
         <div class="row">
           <label>X</label>
-          <input v-model.number="store.player.position.x" type="number" >
+          <input v-model.number="playerDraft.posX" type="number" >
           <label>Y</label>
-          <input v-model.number="store.player.position.y" type="number" >
+          <input v-model.number="playerDraft.posY" type="number" >
         </div>
         <div class="row toggles">
           <label class="toggle">
@@ -132,29 +260,27 @@
             <button class="btn-xs" type="button" @click="warpEnemyToPlayer(e.id)">→Player</button>
             <button class="btn-xs danger" type="button" @click="store.removeEnemy(e.id)">削</button>
           </div>
-          <div class="row">
-            <label>HP</label>
-            <input
-              :value="e.hp"
-              type="number"
-              min="0"
-              @input="(ev) => store.setEnemyStats(e.id, { hp: Number((ev.target as HTMLInputElement).value) })"
-            >
-            <label>ATK</label>
-            <input
-              :value="e.attack"
-              type="number"
-              min="0"
-              @input="(ev) => store.setEnemyStats(e.id, { attack: Number((ev.target as HTMLInputElement).value) })"
-            >
-            <label>DEF</label>
-            <input
-              :value="e.defense"
-              type="number"
-              min="0"
-              @input="(ev) => store.setEnemyStats(e.id, { defense: Number((ev.target as HTMLInputElement).value) })"
-            >
-          </div>
+          <template v-if="enemyDrafts[e.id]">
+            <div class="row">
+              <label>HP</label>
+              <input v-model.number="enemyDrafts[e.id].hp" type="number" min="0" >
+              <label>ATK</label>
+              <input v-model.number="enemyDrafts[e.id].attack" type="number" min="0" >
+            </div>
+            <div class="row">
+              <label>DEF</label>
+              <input v-model.number="enemyDrafts[e.id].defense" type="number" min="0" >
+              <label>回避%</label>
+              <input v-model.number="enemyDrafts[e.id].dodgePct" type="number" min="0" max="100" step="0.5" >
+            </div>
+            <div class="row enemy-actions">
+              <span class="current">
+                現在 HP{{ e.hp }} / ATK{{ e.attack }} / DEF{{ e.defense }} / 回避{{ Math.round((e.dodge ?? 0) * 1000) / 10 }}%
+              </span>
+              <button class="btn-xs" type="button" title="現在値を再読込" @click="resetEnemyDraft(e.id)">↻</button>
+              <button class="btn-xs primary" type="button" @click="saveEnemy(e.id)">保存</button>
+            </div>
+          </template>
         </div>
       </section>
     </div>
@@ -247,6 +373,11 @@
     margin: 0;
   }
 
+  .actions {
+    display: flex;
+    gap: 4px;
+  }
+
   .row {
     display: flex;
     align-items: center;
@@ -311,7 +442,8 @@
     background: rgba(90, 140, 190, 0.9);
   }
 
-  .btn-sm.primary {
+  .btn-sm.primary,
+  .btn-xs.primary {
     background: rgba(80, 140, 90, 0.8);
     border-color: #88bb88;
   }
@@ -351,5 +483,20 @@
     color: #888899;
     flex: 1;
     font-size: 10px;
+  }
+
+  .enemy-actions {
+    margin-top: 2px;
+    margin-bottom: 0;
+  }
+
+  .current {
+    flex: 1;
+    color: #888899;
+    font-size: 10px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 </style>

--- a/components/DebugPanel.client.vue
+++ b/components/DebugPanel.client.vue
@@ -47,6 +47,12 @@
     playerDraft.posY = store.player.position.y
   }
 
+  function notify(msg?: string) {
+    if (typeof window !== 'undefined') {
+      window.__katabasis?.refresh?.(msg)
+    }
+  }
+
   function savePlayer() {
     store.setPlayerStats({
       hp: playerDraft.hp,
@@ -60,7 +66,7 @@
       maxSatiation: playerDraft.maxSatiation,
       position: { x: playerDraft.posX, y: playerDraft.posY },
     })
-    store.addMessage('[DEBUG] プレイヤーを保存')
+    notify('[DEBUG] プレイヤーを保存')
   }
 
   interface EnemyDraft {
@@ -108,7 +114,7 @@
       defense: draft.defense,
       dodge: Math.max(0, Math.min(100, draft.dodgePct)) / 100,
     })
-    store.addMessage('[DEBUG] 敵を保存')
+    notify('[DEBUG] 敵を保存')
   }
 
   watch(
@@ -130,6 +136,18 @@
   const jumpDungeonId = ref(store.dungeon.dungeonId)
   const jumpFloor = ref(store.dungeon.floor)
 
+  const jumpFloorOptions = computed(() => {
+    const def = getDungeon(jumpDungeonId.value)
+    return Array.from({ length: def.floors.length }, (_, i) => i + 1)
+  })
+
+  watch(jumpDungeonId, (id) => {
+    const def = getDungeon(id)
+    if (jumpFloor.value > def.floors.length) {
+      jumpFloor.value = 1
+    }
+  })
+
   function jumpToFloor() {
     const def = getDungeon(jumpDungeonId.value)
     const floor = Math.max(1, Math.min(jumpFloor.value, def.floors.length))
@@ -137,41 +155,47 @@
     gameLoop.initFloor(floor)
     syncPlayerDraft()
     syncEnemyDrafts()
-    store.addMessage(`[DEBUG] ${def.name} ${floor}Fへジャンプ`)
+    notify(`[DEBUG] ${def.name} ${floor}Fへジャンプ`)
   }
 
   function killAllEnemies() {
     const count = store.enemies.length
     store.clearEnemies()
-    store.addMessage(`[DEBUG] ${count}体の敵を消した`)
+    notify(`[DEBUG] ${count}体の敵を消した`)
   }
 
   function fullHeal() {
     store.setPlayerStats({ hp: store.player.maxHp, satiation: store.player.maxSatiation })
     syncPlayerDraft()
-    store.addMessage('[DEBUG] HP・満腹度を全回復')
+    notify('[DEBUG] HP・満腹度を全回復')
   }
 
   function warpEnemyToPlayer(id: string) {
     const p = store.player.position
     store.setEnemyStats(id, { x: p.x, y: p.y - 1 })
+    notify()
+  }
+
+  function removeEnemy(id: string) {
+    store.removeEnemy(id)
+    notify()
   }
 </script>
 
 <template>
   <div v-if="debug.enabled.value" class="debug-panel" :class="{ collapsed }">
     <header class="header">
-      <span class="title">🛠 DEBUG</span>
-      <button class="btn-icon" type="button" @click="collapsed = !collapsed">
+      <span class="title">🛠 デバッグ</span>
+      <button class="btn-icon" type="button" title="折りたたみ" @click="collapsed = !collapsed">
         {{ collapsed ? '▼' : '▲' }}
       </button>
-      <button class="btn-icon" type="button" @click="debug.disable()">✕</button>
+      <button class="btn-icon" type="button" title="閉じる" @click="debug.disable()">✕</button>
     </header>
 
     <div v-if="!collapsed" class="body">
       <section class="section">
         <div class="section-header">
-          <h3>Player</h3>
+          <h3>プレイヤー</h3>
           <div class="actions">
             <button
               class="btn-xs"
@@ -187,13 +211,13 @@
         <div class="row">
           <label>HP</label>
           <input v-model.number="playerDraft.hp" type="number" min="0" >
-          <label>/ Max</label>
+          <label>/ 最大</label>
           <input v-model.number="playerDraft.maxHp" type="number" min="1" >
         </div>
         <div class="row">
-          <label>ATK</label>
+          <label>攻撃</label>
           <input v-model.number="playerDraft.attack" type="number" min="0" >
-          <label>DEF</label>
+          <label>防御</label>
           <input v-model.number="playerDraft.defense" type="number" min="0" >
         </div>
         <div class="row">
@@ -203,13 +227,13 @@
         <div class="row">
           <label>Lv</label>
           <input v-model.number="playerDraft.level" type="number" min="1" >
-          <label>EXP</label>
+          <label>経験値</label>
           <input v-model.number="playerDraft.exp" type="number" min="0" >
         </div>
         <div class="row">
           <label>満腹</label>
           <input v-model.number="playerDraft.satiation" type="number" min="0" >
-          <label>/ Max</label>
+          <label>/ 最大</label>
           <input v-model.number="playerDraft.maxSatiation" type="number" min="1" >
         </div>
         <div class="row">
@@ -219,21 +243,25 @@
           <input v-model.number="playerDraft.posY" type="number" >
         </div>
         <div class="row toggles">
-          <label class="toggle">
+          <label class="toggle" title="敵の攻撃を受けてもダメージを受けない">
             <input v-model="debug.invincible.value" type="checkbox" >
             <span>無敵</span>
           </label>
-          <label class="toggle">
+          <label class="toggle" title="自分の攻撃で必ず一撃で敵を倒す">
             <input v-model="debug.oneShot.value" type="checkbox" >
             <span>ワンパン</span>
           </label>
           <button class="btn-sm" type="button" @click="fullHeal">全回復</button>
         </div>
+        <p class="help">
+          無敵: ダメージ無効化 / ワンパン: 攻撃で必ず一撃必殺
+        </p>
       </section>
 
       <section class="section">
-        <h3>Floor Jump</h3>
+        <h3>階層ジャンプ</h3>
         <div class="row">
+          <label>ダンジョン</label>
           <select v-model="jumpDungeonId">
             <option v-for="d in dungeonOptions" :key="d.id" :value="d.id">
               {{ d.name }} ({{ d.floors }}F)
@@ -241,15 +269,17 @@
           </select>
         </div>
         <div class="row">
-          <label>F</label>
-          <input v-model.number="jumpFloor" type="number" min="1" >
-          <button class="btn-sm primary" type="button" @click="jumpToFloor">Jump</button>
+          <label>階層</label>
+          <select v-model.number="jumpFloor">
+            <option v-for="f in jumpFloorOptions" :key="f" :value="f">{{ f }}F</option>
+          </select>
+          <button class="btn-sm primary" type="button" @click="jumpToFloor">ジャンプ</button>
         </div>
       </section>
 
       <section class="section">
         <div class="section-header">
-          <h3>Enemies ({{ store.enemies.length }})</h3>
+          <h3>敵一覧（{{ store.enemies.length }}体）</h3>
           <button class="btn-sm danger" type="button" @click="killAllEnemies">全消去</button>
         </div>
         <div v-if="store.enemies.length === 0" class="empty">敵はいません</div>
@@ -257,25 +287,25 @@
           <div class="enemy-head">
             <span class="enemy-type">{{ e.type }}</span>
             <span class="enemy-pos">({{ e.x }},{{ e.y }})</span>
-            <button class="btn-xs" type="button" @click="warpEnemyToPlayer(e.id)">→Player</button>
-            <button class="btn-xs danger" type="button" @click="store.removeEnemy(e.id)">削</button>
+            <button class="btn-xs" type="button" title="プレイヤーの隣に移動" @click="warpEnemyToPlayer(e.id)">寄せる</button>
+            <button class="btn-xs danger" type="button" @click="removeEnemy(e.id)">削除</button>
           </div>
           <template v-if="enemyDrafts[e.id]">
             <div class="row">
               <label>HP</label>
               <input v-model.number="enemyDrafts[e.id].hp" type="number" min="0" >
-              <label>ATK</label>
+              <label>攻撃</label>
               <input v-model.number="enemyDrafts[e.id].attack" type="number" min="0" >
             </div>
             <div class="row">
-              <label>DEF</label>
+              <label>防御</label>
               <input v-model.number="enemyDrafts[e.id].defense" type="number" min="0" >
               <label>回避%</label>
               <input v-model.number="enemyDrafts[e.id].dodgePct" type="number" min="0" max="100" step="0.5" >
             </div>
             <div class="row enemy-actions">
               <span class="current">
-                現在 HP{{ e.hp }} / ATK{{ e.attack }} / DEF{{ e.defense }} / 回避{{ Math.round((e.dodge ?? 0) * 1000) / 10 }}%
+                現在 HP{{ e.hp }} / 攻撃{{ e.attack }} / 防御{{ e.defense }} / 回避{{ Math.round((e.dodge ?? 0) * 1000) / 10 }}%
               </span>
               <button class="btn-xs" type="button" title="現在値を再読込" @click="resetEnemyDraft(e.id)">↻</button>
               <button class="btn-xs primary" type="button" @click="saveEnemy(e.id)">保存</button>
@@ -387,8 +417,16 @@
 
   .row label {
     color: #aaaacc;
-    min-width: 28px;
+    min-width: 40px;
     font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .help {
+    margin: 4px 0 0;
+    color: #777799;
+    font-size: 10px;
+    line-height: 1.4;
   }
 
   .row input[type='number'],

--- a/components/DebugPanel.client.vue
+++ b/components/DebugPanel.client.vue
@@ -1,0 +1,355 @@
+<script setup lang="ts">
+  import { computed, ref } from 'vue'
+  import { useGameStore } from '~/stores/gameStore'
+  import { useGameLoop } from '~/composables/useGameLoop'
+  import { useDebugMode } from '~/composables/useDebugMode'
+  import { DUNGEONS, getDungeon } from '~/game/dungeon'
+
+  const store = useGameStore()
+  const gameLoop = useGameLoop()
+  const debug = useDebugMode()
+
+  const collapsed = ref(false)
+
+  const dungeonOptions = computed(() =>
+    Object.entries(DUNGEONS).map(([id, def]) => ({
+      id,
+      name: def.name,
+      floors: def.floors.length,
+    }))
+  )
+
+  const jumpDungeonId = ref(store.dungeon.dungeonId)
+  const jumpFloor = ref(store.dungeon.floor)
+
+  function jumpToFloor() {
+    const def = getDungeon(jumpDungeonId.value)
+    const floor = Math.max(1, Math.min(jumpFloor.value, def.floors.length))
+    store.setDungeonState(jumpDungeonId.value, def.floors.length, floor)
+    gameLoop.initFloor(floor)
+    store.addMessage(`[DEBUG] ${def.name} ${floor}Fへジャンプ`)
+  }
+
+  function killAllEnemies() {
+    const count = store.enemies.length
+    store.clearEnemies()
+    store.addMessage(`[DEBUG] ${count}体の敵を消した`)
+  }
+
+  function fullHeal() {
+    store.setPlayerStats({ hp: store.player.maxHp, satiation: store.player.maxSatiation })
+    store.addMessage('[DEBUG] HP・満腹度を全回復')
+  }
+
+  function warpEnemyToPlayer(id: string) {
+    const p = store.player.position
+    store.setEnemyStats(id, { x: p.x, y: p.y - 1 })
+  }
+</script>
+
+<template>
+  <div v-if="debug.enabled.value" class="debug-panel" :class="{ collapsed }">
+    <header class="header">
+      <span class="title">🛠 DEBUG</span>
+      <button class="btn-icon" type="button" @click="collapsed = !collapsed">
+        {{ collapsed ? '▼' : '▲' }}
+      </button>
+      <button class="btn-icon" type="button" @click="debug.disable()">✕</button>
+    </header>
+
+    <div v-if="!collapsed" class="body">
+      <section class="section">
+        <h3>Player</h3>
+        <div class="row">
+          <label>HP</label>
+          <input v-model.number="store.player.hp" type="number" min="0" >
+          <label>/ Max</label>
+          <input v-model.number="store.player.maxHp" type="number" min="1" >
+        </div>
+        <div class="row">
+          <label>ATK</label>
+          <input v-model.number="store.player.attack" type="number" min="0" >
+          <label>DEF</label>
+          <input v-model.number="store.player.defense" type="number" min="0" >
+        </div>
+        <div class="row">
+          <label>Lv</label>
+          <input v-model.number="store.player.level" type="number" min="1" >
+          <label>EXP</label>
+          <input v-model.number="store.player.exp" type="number" min="0" >
+        </div>
+        <div class="row">
+          <label>満腹</label>
+          <input v-model.number="store.player.satiation" type="number" min="0" >
+          <label>/ Max</label>
+          <input v-model.number="store.player.maxSatiation" type="number" min="1" >
+        </div>
+        <div class="row">
+          <label>X</label>
+          <input v-model.number="store.player.position.x" type="number" >
+          <label>Y</label>
+          <input v-model.number="store.player.position.y" type="number" >
+        </div>
+        <div class="row toggles">
+          <label class="toggle">
+            <input v-model="debug.invincible.value" type="checkbox" >
+            <span>無敵</span>
+          </label>
+          <label class="toggle">
+            <input v-model="debug.oneShot.value" type="checkbox" >
+            <span>ワンパン</span>
+          </label>
+          <button class="btn-sm" type="button" @click="fullHeal">全回復</button>
+        </div>
+      </section>
+
+      <section class="section">
+        <h3>Floor Jump</h3>
+        <div class="row">
+          <select v-model="jumpDungeonId">
+            <option v-for="d in dungeonOptions" :key="d.id" :value="d.id">
+              {{ d.name }} ({{ d.floors }}F)
+            </option>
+          </select>
+        </div>
+        <div class="row">
+          <label>F</label>
+          <input v-model.number="jumpFloor" type="number" min="1" >
+          <button class="btn-sm primary" type="button" @click="jumpToFloor">Jump</button>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <h3>Enemies ({{ store.enemies.length }})</h3>
+          <button class="btn-sm danger" type="button" @click="killAllEnemies">全消去</button>
+        </div>
+        <div v-if="store.enemies.length === 0" class="empty">敵はいません</div>
+        <div v-for="e in store.enemies" :key="e.id" class="enemy">
+          <div class="enemy-head">
+            <span class="enemy-type">{{ e.type }}</span>
+            <span class="enemy-pos">({{ e.x }},{{ e.y }})</span>
+            <button class="btn-xs" type="button" @click="warpEnemyToPlayer(e.id)">→Player</button>
+            <button class="btn-xs danger" type="button" @click="store.removeEnemy(e.id)">削</button>
+          </div>
+          <div class="row">
+            <label>HP</label>
+            <input
+              :value="e.hp"
+              type="number"
+              min="0"
+              @input="(ev) => store.setEnemyStats(e.id, { hp: Number((ev.target as HTMLInputElement).value) })"
+            >
+            <label>ATK</label>
+            <input
+              :value="e.attack"
+              type="number"
+              min="0"
+              @input="(ev) => store.setEnemyStats(e.id, { attack: Number((ev.target as HTMLInputElement).value) })"
+            >
+            <label>DEF</label>
+            <input
+              :value="e.defense"
+              type="number"
+              min="0"
+              @input="(ev) => store.setEnemyStats(e.id, { defense: Number((ev.target as HTMLInputElement).value) })"
+            >
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .debug-panel {
+    position: fixed;
+    top: 8px;
+    right: 8px;
+    width: 280px;
+    max-height: calc(100vh - 16px);
+    background: rgba(20, 20, 30, 0.92);
+    color: #e0e0ff;
+    border: 1px solid #8888aa;
+    border-radius: 4px;
+    font-family: 'DotGothic16', monospace;
+    font-size: 12px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    backdrop-filter: blur(2px);
+  }
+
+  .debug-panel.collapsed {
+    width: auto;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    background: rgba(60, 60, 80, 0.8);
+    border-bottom: 1px solid #555577;
+  }
+
+  .title {
+    flex: 1;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+
+  .btn-icon {
+    width: 22px;
+    height: 22px;
+    background: rgba(80, 80, 100, 0.6);
+    border: 1px solid #666688;
+    color: #e0e0ff;
+    font-size: 11px;
+    cursor: pointer;
+    border-radius: 2px;
+  }
+
+  .btn-icon:hover {
+    background: rgba(100, 100, 130, 0.8);
+  }
+
+  .body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px;
+  }
+
+  .section {
+    padding: 4px 0 8px;
+    border-bottom: 1px dashed #444466;
+  }
+
+  .section:last-child {
+    border-bottom: none;
+  }
+
+  .section h3 {
+    margin: 0 0 4px;
+    font-size: 13px;
+    color: #ffcc88;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+  }
+
+  .section-header h3 {
+    margin: 0;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+
+  .row label {
+    color: #aaaacc;
+    min-width: 28px;
+    font-size: 11px;
+  }
+
+  .row input[type='number'],
+  .row select {
+    flex: 1;
+    min-width: 0;
+    background: rgba(40, 40, 60, 0.8);
+    color: #fff;
+    border: 1px solid #555577;
+    border-radius: 2px;
+    padding: 2px 4px;
+    font-family: inherit;
+    font-size: 12px;
+  }
+
+  .toggles {
+    justify-content: space-between;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    min-width: auto;
+  }
+
+  .toggle input {
+    cursor: pointer;
+  }
+
+  .btn-sm,
+  .btn-xs {
+    background: rgba(70, 110, 150, 0.7);
+    border: 1px solid #6688aa;
+    color: #fff;
+    padding: 2px 6px;
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    border-radius: 2px;
+  }
+
+  .btn-xs {
+    padding: 1px 4px;
+    font-size: 10px;
+  }
+
+  .btn-sm:hover,
+  .btn-xs:hover {
+    background: rgba(90, 140, 190, 0.9);
+  }
+
+  .btn-sm.primary {
+    background: rgba(80, 140, 90, 0.8);
+    border-color: #88bb88;
+  }
+
+  .btn-sm.danger,
+  .btn-xs.danger {
+    background: rgba(160, 60, 60, 0.8);
+    border-color: #cc6666;
+  }
+
+  .empty {
+    color: #777799;
+    font-style: italic;
+    padding: 4px 0;
+  }
+
+  .enemy {
+    background: rgba(40, 40, 60, 0.5);
+    padding: 4px;
+    margin-bottom: 4px;
+    border-radius: 2px;
+  }
+
+  .enemy-head {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+
+  .enemy-type {
+    color: #ffaa88;
+    font-weight: bold;
+  }
+
+  .enemy-pos {
+    color: #888899;
+    flex: 1;
+    font-size: 10px;
+  }
+</style>

--- a/components/DebugPanel.client.vue
+++ b/components/DebugPanel.client.vue
@@ -8,6 +8,10 @@
   const store = useGameStore()
   const gameLoop = useGameLoop()
   const debug = useDebugMode()
+  // v-model でリアクティブに更新するには top-level の ref が必要 (nested の ref は auto-unwrap されない)
+  const debugEnabled = debug.enabled
+  const debugInvincible = debug.invincible
+  const debugOneShot = debug.oneShot
 
   const collapsed = ref(false)
 
@@ -183,13 +187,12 @@
 </script>
 
 <template>
-  <div v-if="debug.enabled.value" class="debug-panel" :class="{ collapsed }">
+  <div v-if="debugEnabled" class="debug-panel" :class="{ collapsed }">
     <header class="header">
       <span class="title">🛠 デバッグ</span>
       <button class="btn-icon" type="button" title="折りたたみ" @click="collapsed = !collapsed">
         {{ collapsed ? '▼' : '▲' }}
       </button>
-      <button class="btn-icon" type="button" title="閉じる" @click="debug.disable()">✕</button>
     </header>
 
     <div v-if="!collapsed" class="body">
@@ -244,11 +247,11 @@
         </div>
         <div class="row toggles">
           <label class="toggle" title="敵の攻撃を受けてもダメージを受けない">
-            <input v-model="debug.invincible.value" type="checkbox" >
+            <input v-model="debugInvincible" type="checkbox" >
             <span>無敵</span>
           </label>
           <label class="toggle" title="自分の攻撃で必ず一撃で敵を倒す">
-            <input v-model="debug.oneShot.value" type="checkbox" >
+            <input v-model="debugOneShot" type="checkbox" >
             <span>ワンパン</span>
           </label>
           <button class="btn-sm" type="button" @click="fullHeal">全回復</button>
@@ -321,7 +324,7 @@
   .debug-panel {
     position: fixed;
     top: 8px;
-    right: 8px;
+    left: 8px;
     width: 280px;
     max-height: calc(100vh - 16px);
     background: rgba(20, 20, 30, 0.92);

--- a/composables/useDebugMode.ts
+++ b/composables/useDebugMode.ts
@@ -1,0 +1,97 @@
+import { ref } from 'vue'
+
+const KONAMI_SEQUENCE = [
+  'ArrowUp',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowRight',
+  'KeyB',
+  'KeyA',
+]
+
+const enabled = ref(false)
+const invincible = ref(false)
+const oneShot = ref(false)
+
+const onEnableCallbacks = new Set<() => void>()
+const onDisableCallbacks = new Set<() => void>()
+
+let buffer: string[] = []
+let listenerAttached = false
+
+function handleKeyDown(e: KeyboardEvent) {
+  buffer.push(e.code)
+  if (buffer.length > KONAMI_SEQUENCE.length) {
+    buffer.shift()
+  }
+  if (
+    buffer.length === KONAMI_SEQUENCE.length &&
+    buffer.every((k, i) => k === KONAMI_SEQUENCE[i])
+  ) {
+    toggle()
+    buffer = []
+  }
+}
+
+function enable() {
+  if (enabled.value) return
+  enabled.value = true
+  onEnableCallbacks.forEach((cb) => cb())
+}
+
+function disable() {
+  if (!enabled.value) return
+  enabled.value = false
+  invincible.value = false
+  oneShot.value = false
+  onDisableCallbacks.forEach((cb) => cb())
+}
+
+function toggle() {
+  if (enabled.value) {
+    disable()
+  } else {
+    enable()
+  }
+}
+
+function attachListener() {
+  if (listenerAttached || typeof window === 'undefined') return
+  window.addEventListener('keydown', handleKeyDown)
+  listenerAttached = true
+}
+
+function detachListener() {
+  if (!listenerAttached || typeof window === 'undefined') return
+  window.removeEventListener('keydown', handleKeyDown)
+  listenerAttached = false
+}
+
+function onEnable(cb: () => void) {
+  onEnableCallbacks.add(cb)
+  return () => onEnableCallbacks.delete(cb)
+}
+
+function onDisable(cb: () => void) {
+  onDisableCallbacks.add(cb)
+  return () => onDisableCallbacks.delete(cb)
+}
+
+export function useDebugMode() {
+  return {
+    enabled,
+    invincible,
+    oneShot,
+    enable,
+    disable,
+    toggle,
+    attachListener,
+    detachListener,
+    onEnable,
+    onDisable,
+  }
+}

--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -6,6 +6,7 @@ import { ITEMS } from '~/game/data/items'
 import { generateFloor } from '~/game/systems/DungeonGenerator'
 import { getFloorDifficulty } from '~/game/data/floorConfig'
 import { getDungeon, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
+import { useDebugMode } from '~/composables/useDebugMode'
 
 const turnManager = new TurnManager()
 const combatSystem = new CombatSystem()
@@ -38,6 +39,7 @@ function getEnemyName(type: string): string {
 
 export function useGameLoop() {
   const store = useGameStore()
+  const debug = useDebugMode()
 
   function enemyAttackPlayer(enemy: {
     type: string
@@ -52,6 +54,10 @@ export function useGameLoop() {
       { attack: enemy.attack },
       { attack: store.player.attack, defense: store.player.defense }
     )
+
+    if (debug.invincible.value && !result.isDodged) {
+      result.damage = 0
+    }
 
     const event: CombatEvent = {
       type: 'enemyAttack',
@@ -140,6 +146,11 @@ export function useGameLoop() {
         { attack: store.player.attack },
         { attack: target.attack, defense: target.defense }
       )
+
+      if (debug.oneShot.value) {
+        result.damage = target.hp
+        result.isDodged = false
+      }
 
       let killed = false
 

--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -52,7 +52,7 @@ export function useGameLoop() {
     const name = getEnemyName(enemy.type)
     const result = combatSystem.calculateDamage(
       { attack: enemy.attack },
-      { attack: store.player.attack, defense: store.player.defense }
+      { attack: store.player.attack, defense: store.player.defense, dodge: store.player.dodge }
     )
 
     if (debug.invincible.value && !result.isDodged) {
@@ -144,7 +144,7 @@ export function useGameLoop() {
       const name = getEnemyName(target.type)
       const result = combatSystem.calculateDamage(
         { attack: store.player.attack },
-        { attack: target.attack, defense: target.defense }
+        { attack: target.attack, defense: target.defense, dodge: target.dodge }
       )
 
       if (debug.oneShot.value) {

--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -12,6 +12,7 @@
     "maxHealth": 100,
     "attack": 10,
     "defense": 5,
+    "dodge": 0.05,
     "viewRange": 6
   },
   "enemyTypes": {
@@ -19,13 +20,15 @@
       "maxHealth": 20,
       "attack": 5,
       "defense": 2,
-      "exp": 10
+      "exp": 10,
+      "dodge": 0.05
     },
     "goblin": {
       "maxHealth": 30,
       "attack": 8,
       "defense": 3,
-      "exp": 20
+      "exp": 20,
+      "dodge": 0.08
     }
   },
   "itemTypes": {

--- a/game/entities/Enemy.ts
+++ b/game/entities/Enemy.ts
@@ -9,6 +9,7 @@ export interface EnemyStats {
   attack: number
   defense: number
   exp: number
+  dodge?: number
 }
 
 export interface EnemyData {
@@ -19,6 +20,7 @@ export interface EnemyData {
   attack: number
   defense: number
   exp: number
+  dodge: number
   position: Position
   aiState: AIState
 }
@@ -33,6 +35,7 @@ export interface EnemyStoreState {
   attack: number
   defense: number
   exp: number
+  dodge: number
   aiState: string
 }
 
@@ -48,6 +51,7 @@ export class Enemy {
       attack: stats.attack,
       defense: stats.defense,
       exp: stats.exp,
+      dodge: stats.dodge ?? 0.05,
       position: { ...position },
       aiState: 'idle',
     }
@@ -75,6 +79,10 @@ export class Enemy {
 
   get exp(): number {
     return this.data.exp
+  }
+
+  get dodge(): number {
+    return this.data.dodge
   }
 
   get position(): Position {
@@ -119,6 +127,7 @@ export class Enemy {
       attack: this.data.attack,
       defense: this.data.defense,
       exp: this.data.exp,
+      dodge: this.data.dodge,
       aiState: this.data.aiState,
     }
   }

--- a/game/entities/Goblin.ts
+++ b/game/entities/Goblin.ts
@@ -8,7 +8,14 @@ export class Goblin extends Enemy {
   constructor(position: Position, id?: string) {
     super(
       'goblin',
-      { hp: cfg.maxHealth, maxHp: cfg.maxHealth, attack: cfg.attack, defense: cfg.defense, exp: cfg.exp },
+      {
+        hp: cfg.maxHealth,
+        maxHp: cfg.maxHealth,
+        attack: cfg.attack,
+        defense: cfg.defense,
+        exp: cfg.exp,
+        dodge: cfg.dodge,
+      },
       position,
       id
     )

--- a/game/entities/Skeleton.ts
+++ b/game/entities/Skeleton.ts
@@ -8,7 +8,14 @@ export class Skeleton extends Enemy {
   constructor(position: Position, id?: string) {
     super(
       'skeleton',
-      { hp: cfg.maxHealth, maxHp: cfg.maxHealth, attack: cfg.attack, defense: cfg.defense, exp: cfg.exp },
+      {
+        hp: cfg.maxHealth,
+        maxHp: cfg.maxHealth,
+        attack: cfg.attack,
+        defense: cfg.defense,
+        exp: cfg.exp,
+        dodge: cfg.dodge,
+      },
       position,
       id
     )

--- a/game/systems/CombatSystem.ts
+++ b/game/systems/CombatSystem.ts
@@ -7,6 +7,7 @@ export interface CombatResult {
 export interface Combatant {
   attack: number
   defense?: number
+  dodge?: number
 }
 
 export class CombatSystem {
@@ -14,8 +15,9 @@ export class CombatSystem {
   private dodgeChance = 0.05
 
   calculateDamage(attacker: Combatant, defender: Combatant): CombatResult {
-    // 回避判定
-    if (Math.random() < this.dodgeChance) {
+    // 回避判定 (defender.dodge が未指定なら既定値)
+    const dodgeRate = defender.dodge ?? this.dodgeChance
+    if (Math.random() < dodgeRate) {
       return { damage: 0, isCritical: false, isDodged: true }
     }
 

--- a/pages/game.vue
+++ b/pages/game.vue
@@ -5,6 +5,7 @@
 <template>
   <div class="game-screen">
     <GameCanvas />
+    <DebugPanel />
   </div>
 </template>
 

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -132,6 +132,18 @@ export class DungeonScene extends Phaser.Scene {
     this.setupTouchInput()
 
     this.scene.launch('UIScene')
+
+    // デバッグパネルからの全画面再描画フックを登録（plugins/debug.client.ts で __katabasis 初期化済み）
+    if (window.__katabasis) {
+      window.__katabasis.refresh = (message?: string) => {
+        this.syncMapFromStore()
+        this.drawScene()
+        this.updateUI(message ? [message] : [])
+      }
+    }
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      if (window.__katabasis) window.__katabasis.refresh = undefined
+    })
   }
 
   private createAnimations() {

--- a/plugins/debug.client.ts
+++ b/plugins/debug.client.ts
@@ -13,6 +13,8 @@ declare global {
         setInvincible: (v: boolean) => void
         setOneShot: (v: boolean) => void
       }
+      /** Phaser シーンが登録する全画面再描画フック (DungeonScene.create で設定) */
+      refresh?: (message?: string) => void
     }
   }
 }

--- a/plugins/debug.client.ts
+++ b/plugins/debug.client.ts
@@ -1,0 +1,48 @@
+import { useDebugMode } from '~/composables/useDebugMode'
+
+declare global {
+  interface Window {
+    __katabasis?: {
+      debug: {
+        enable: () => void
+        disable: () => void
+        toggle: () => void
+        readonly enabled: boolean
+        readonly invincible: boolean
+        readonly oneShot: boolean
+        setInvincible: (v: boolean) => void
+        setOneShot: (v: boolean) => void
+      }
+    }
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const debug = useDebugMode()
+  debug.attachListener()
+
+  if (typeof window === 'undefined') return
+
+  window.__katabasis = {
+    debug: {
+      enable: debug.enable,
+      disable: debug.disable,
+      toggle: debug.toggle,
+      get enabled() {
+        return debug.enabled.value
+      },
+      get invincible() {
+        return debug.invincible.value
+      },
+      get oneShot() {
+        return debug.oneShot.value
+      },
+      setInvincible(v: boolean) {
+        debug.invincible.value = v
+      },
+      setOneShot(v: boolean) {
+        debug.oneShot.value = v
+      },
+    },
+  }
+})

--- a/plugins/debug.client.ts
+++ b/plugins/debug.client.ts
@@ -23,6 +23,8 @@ export default defineNuxtPlugin(() => {
 
   if (typeof window === 'undefined') return
 
+  console.log('↑ ↑ ↓ ↓ ← → ← → B A')
+
   window.__katabasis = {
     debug: {
       enable: debug.enable,

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -9,6 +9,7 @@ interface PlayerState {
   maxSatiation: number
   attack: number
   defense: number
+  dodge: number
   direction: { dx: number; dy: number }
   position: { x: number; y: number }
 }
@@ -23,6 +24,7 @@ interface EnemyState {
   attack: number
   defense: number
   exp: number
+  dodge: number
   aiState: string
 }
 
@@ -67,6 +69,7 @@ export const useGameStore = defineStore('game', {
       maxSatiation: 100,
       attack: 10,
       defense: 5,
+      dodge: 0.05,
       direction: { dx: 0, dy: 1 },
       position: { x: 7, y: 7 },
     },

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -122,6 +122,23 @@ export const useGameStore = defineStore('game', {
       this.dungeon.floor = 1
     },
 
+    setDungeonState(dungeonId: string, totalFloors: number, floor: number) {
+      this.dungeon.dungeonId = dungeonId
+      this.dungeon.totalFloors = totalFloors
+      this.dungeon.floor = floor
+    },
+
+    setPlayerStats(stats: Partial<PlayerState>) {
+      Object.assign(this.player, stats)
+    },
+
+    setEnemyStats(id: string, stats: Partial<Omit<EnemyState, 'id'>>) {
+      const enemy = this.enemies.find((e) => e.id === id)
+      if (enemy) {
+        Object.assign(enemy, stats)
+      }
+    },
+
     endTurn() {
       this.turn++
     },

--- a/tests/unit/entities/Enemy.test.ts
+++ b/tests/unit/entities/Enemy.test.ts
@@ -98,6 +98,7 @@ describe('Enemy（共通機能）', () => {
         attack: 5,
         defense: 2,
         exp: 10,
+        dodge: 0.05,
         aiState: 'idle',
       })
     })


### PR DESCRIPTION
Closes #57

## 概要

開発・QA 用の管理者向けデバッグモードを追加。プレイヤー／現フロアの敵のパラメータを編集、任意の階層へジャンプ、無敵・ワンパンの切替が可能。通常プレイ時は隠しコマンドで起動する。

## 起動方法

- **コナミコマンド**: ゲーム画面で `↑ ↑ ↓ ↓ ← → ← → B A` を入力 → 有効化／無効化トグル
- **DevTools API**: `window.__katabasis.debug.enable()` / `disable()` / `toggle()`
- アプリ起動時にブラウザコンソールにキーシーケンスをヒント表示

## 機能

- 右上に Vue オーバーレイの「🛠 デバッグ」パネルを表示
- **プレイヤー編集**: HP / 最大HP / 攻撃 / 防御 / 回避% / Lv / 経験値 / 満腹 / 座標
- **敵編集**: 現フロアの敵を一覧表示、HP / 攻撃 / 防御 / 回避% を個別編集、プレイヤーへ寄せる / 削除 / 全消去
- **階層ジャンプ**: ダンジョン選択 + 階層 select で任意のフロアへ即座に移動
- **トグル**: 無敵（被ダメ無効化） / ワンパン（攻撃で必ず一撃必殺） / 全回復
- 入力はドラフト保持、明示的な「保存」ボタンで反映
- DebugPanel の編集後は Phaser シーンを即時再描画（マップ・ステータスバー含む）

## 主な変更

- 戦闘システム: Combatant に `dodge` を追加。Player/Enemy の回避率を個別に持つように
- gameConfig: スケルトン 5% / ゴブリン 8% / プレイヤー 5%
- Pinia: `setPlayerStats` / `setEnemyStats` / `setDungeonState` action を追加
- Phaser: `window.__katabasis.refresh()` で外部から全画面再描画を呼べるフックを追加
- 既存テスト 106 件はそのままパス（Enemy.toStoreState のスナップショットだけ dodge 追加で更新）

## コミット一覧

- feat: デバッグモード本体（コナミ検知 + パネル + invincible/oneShot）
- feat(debug): 回避率パラメータ + 保存ボタン式 UI
- chore(debug): 起動時コンソールヒント
- feat(debug): UI 日本語化 + 階層ドロップダウン + Phaser 再描画フック

## 検証

- [x] `npm run lint` 通る
- [x] `npm run test` 全 106 件パス
- [x] `npx nuxt typecheck` エラーなし
- [x] Docker 起動でブラウザ動作確認（コナミ起動、ステータス即時反映、階層ジャンプ）

## 注意

- sessionStorage に古いゲーム状態が残っているとプレイヤー/敵の `dodge` が未定義のまま読み込まれます。戦闘時は CombatSystem 側で既定値 5% にフォールバックするため動作に支障はありませんが、デバッグパネル上は 0% 表示になります。フロアジャンプか新規開始で正しい値が入ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プレイヤーと敵の回避能力（回避率）を追加し、戦闘の回避判定が反映されるようになりました。
  * デバッグパネルを追加し、敵/プレイヤーのステータス表示・編集や、全回復・全敵削除・敵ワープなどの操作、無敵/ワンショット切り替えが可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->