### PR TITLE
feat: 8方向移動 (#13)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -2,6 +2,7 @@ import { useGameStore } from '~/stores/gameStore'
 import { TurnManager } from '~/game/systems/TurnManager'
 import { CombatSystem } from '~/game/systems/CombatSystem'
 import { decideAction } from '~/game/systems/EnemyAI'
+import { canMoveDiagonally } from '~/game/systems/movement'
 import { generateFloor } from '~/game/systems/DungeonGenerator'
 import { getFloorDifficulty } from '~/game/data/floorConfig'
 import { getDungeon, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
@@ -271,6 +272,15 @@ export function useGameLoop() {
       newX < 0 ||
       newX >= map[0].length ||
       map[newY][newX] === 1
+    ) {
+      return null
+    }
+
+    // 斜め移動時は壁角のすり抜けを禁止
+    if (
+      dx !== 0 &&
+      dy !== 0 &&
+      !canMoveDiagonally(map, store.player.position.x, store.player.position.y, dx, dy)
     ) {
       return null
     }

--- a/game/systems/EnemyAI.ts
+++ b/game/systems/EnemyAI.ts
@@ -1,3 +1,5 @@
+import { canMoveDiagonally } from './movement'
+
 interface Position {
   x: number
   y: number
@@ -22,6 +24,10 @@ const DIRECTIONS = [
   { dx: 0, dy: 1 }, // 下
   { dx: -1, dy: 0 }, // 左
   { dx: 1, dy: 0 }, // 右
+  { dx: -1, dy: -1 }, // 左上
+  { dx: 1, dy: -1 }, // 右上
+  { dx: -1, dy: 1 }, // 左下
+  { dx: 1, dy: 1 }, // 右下
 ]
 
 const AI_CONFIG: Record<string, { detectRange: number; chaseRange: number }> = {
@@ -40,12 +46,33 @@ function chebyshevDistance(a: Position, b: Position): number {
 export function isAdjacent(a: Position, b: Position): boolean {
   const dx = Math.abs(a.x - b.x)
   const dy = Math.abs(a.y - b.y)
-  return (dx === 1 && dy === 0) || (dx === 0 && dy === 1)
+  // Chebyshev 距離 1（縦横斜めの隣接すべて true、同一マスは false）
+  return dx <= 1 && dy <= 1 && dx + dy > 0
+}
+
+/**
+ * 指定マスへ移動可能か判定する（範囲外・壁・占有・斜め角抜けを排除）。
+ */
+function canEnter(
+  enemy: Position,
+  nx: number,
+  ny: number,
+  map: number[][],
+  occupied: Position[]
+): boolean {
+  if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) return false
+  if (map[ny][nx] === 1) return false
+  if (occupied.some((p) => p.x === nx && p.y === ny)) return false
+  const dx = nx - enemy.x
+  const dy = ny - enemy.y
+  // 斜め移動時は壁角のすり抜けを禁止
+  if (dx !== 0 && dy !== 0 && !canMoveDiagonally(map, enemy.x, enemy.y, dx, dy)) return false
+  return true
 }
 
 /**
  * ランダム移動AI
- * 4方向からランダムに移動先を選ぶ。壁・範囲外・占有済みマスは避ける。
+ * 8方向からランダムに移動先を選ぶ。壁・範囲外・占有済みマス・斜め角抜けは避ける。
  */
 export function randomMove(
   enemy: Position,
@@ -59,20 +86,17 @@ export function randomMove(
   for (const { dx, dy } of shuffled) {
     const nx = enemy.x + dx
     const ny = enemy.y + dy
-
-    if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) continue
-    if (map[ny][nx] === 1) continue
-    if (occupied.some((p) => p.x === nx && p.y === ny)) continue
-
-    return { x: nx, y: ny }
+    if (canEnter(enemy, nx, ny, map, occupied)) {
+      return { x: nx, y: ny }
+    }
   }
 
   return null
 }
 
 /**
- * プレイヤー方向への貪欲移動
- * dx/dyの大きい方を優先し、壁ならもう一方を試行
+ * プレイヤー方向への貪欲移動（8方向）
+ * まず斜めを含めた理想方向を試し、塞がれていれば直交方向へフォールバックする。
  */
 export function moveToward(
   enemy: Position,
@@ -82,23 +106,31 @@ export function moveToward(
 ): Position | null {
   const dx = target.x - enemy.x
   const dy = target.y - enemy.y
+  const sx = Math.sign(dx)
+  const sy = Math.sign(dy)
 
-  // 優先方向を決定（距離が大きい軸を先に試す）
   const candidates: { nx: number; ny: number }[] = []
 
+  // 1. 斜め方向（両軸ともズレている場合）
+  if (sx !== 0 && sy !== 0) {
+    candidates.push({ nx: enemy.x + sx, ny: enemy.y + sy })
+  }
+
+  // 2. 直交方向フォールバック（距離が大きい軸を優先）
+  const straightX = { nx: enemy.x + sx, ny: enemy.y }
+  const straightY = { nx: enemy.x, ny: enemy.y + sy }
   if (Math.abs(dx) >= Math.abs(dy)) {
-    if (dx !== 0) candidates.push({ nx: enemy.x + Math.sign(dx), ny: enemy.y })
-    if (dy !== 0) candidates.push({ nx: enemy.x, ny: enemy.y + Math.sign(dy) })
+    if (sx !== 0) candidates.push(straightX)
+    if (sy !== 0) candidates.push(straightY)
   } else {
-    if (dy !== 0) candidates.push({ nx: enemy.x, ny: enemy.y + Math.sign(dy) })
-    if (dx !== 0) candidates.push({ nx: enemy.x + Math.sign(dx), ny: enemy.y })
+    if (sy !== 0) candidates.push(straightY)
+    if (sx !== 0) candidates.push(straightX)
   }
 
   for (const { nx, ny } of candidates) {
-    if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) continue
-    if (map[ny][nx] === 1) continue
-    if (occupied.some((p) => p.x === nx && p.y === ny)) continue
-    return { x: nx, y: ny }
+    if (canEnter(enemy, nx, ny, map, occupied)) {
+      return { x: nx, y: ny }
+    }
   }
 
   return null

--- a/game/systems/movement.ts
+++ b/game/systems/movement.ts
@@ -1,0 +1,41 @@
+import { TILE } from '../data/maps'
+
+/**
+ * 指定座標が壁（または範囲外）かどうかを判定する。
+ * 範囲外は壁扱い（移動をブロックする）。
+ */
+function isBlocking(map: number[][], x: number, y: number): boolean {
+  if (map.length === 0 || map[0].length === 0) return true
+  if (y < 0 || y >= map.length || x < 0 || x >= map[0].length) return true
+  return map[y][x] === TILE.WALL
+}
+
+/**
+ * 斜め移動時の「壁角すり抜け（corner-cut）」を禁止するための判定。
+ *
+ * 斜め (dx≠0 かつ dy≠0) に移動しようとするとき、移動元から見て
+ * 隣接する2つの直交マス（横方向・縦方向）のいずれかが壁（または範囲外）なら
+ * 斜め移動を許可しない。直交移動（縦横）の場合は常に true を返す。
+ *
+ * @param map   マップ（0=床/2=階段=通行可, 1=壁）
+ * @param fromX 移動元 X
+ * @param fromY 移動元 Y
+ * @param dx    X 方向の移動量 (-1|0|1)
+ * @param dy    Y 方向の移動量 (-1|0|1)
+ * @returns 斜め移動が許可されるなら true
+ */
+export function canMoveDiagonally(
+  map: number[][],
+  fromX: number,
+  fromY: number,
+  dx: number,
+  dy: number
+): boolean {
+  // 斜めでなければ corner-cut の概念は無い
+  if (dx === 0 || dy === 0) return true
+
+  // 横隣・縦隣のどちらかが壁なら斜めに抜けられない
+  if (isBlocking(map, fromX + dx, fromY)) return false
+  if (isBlocking(map, fromX, fromY + dy)) return false
+  return true
+}

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -63,6 +63,10 @@ export class DungeonScene extends Phaser.Scene {
   // 演出中の入力ロック
   private inputLocked = false
 
+  // キーボード8方向移動: 押下中の移動キー集合と、1フレーム内の移動合成フラグ
+  private heldMoveKeys = new Set<string>()
+  private movePending = false
+
   // BGM
   private currentBgm: Phaser.Sound.BaseSound | null = null
   private currentBgmKey = ''
@@ -497,7 +501,8 @@ export class DungeonScene extends Phaser.Scene {
       const x = this.offsetX + screenTileX * this.tileWidth + this.tileWidth / 2
       const y = this.offsetY + screenTileY * this.tileHeight + this.tileHeight / 2
       const def = ITEMS[item.itemId]
-      const spriteKey = def?.sprite && this.textures.exists(def.sprite) ? def.sprite : 'weapon_sword'
+      const spriteKey =
+        def?.sprite && this.textures.exists(def.sprite) ? def.sprite : 'weapon_sword'
       const sprite = this.add.image(x, y, spriteKey)
       // 専用スプライト (flask 等) は元画像が小さいので大きめに描画する
       const scaleFactor = spriteKey === 'weapon_sword' ? 0.35 : 0.55
@@ -541,37 +546,71 @@ export class DungeonScene extends Phaser.Scene {
 
   // --- 入力 ---
 
+  private static readonly MOVE_KEYS = [
+    'ArrowUp',
+    'KeyW',
+    'ArrowDown',
+    'KeyS',
+    'ArrowLeft',
+    'KeyA',
+    'ArrowRight',
+    'KeyD',
+  ]
+
   private setupInput() {
-    this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
-      let dx = 0
-      let dy = 0
+    const keyboard = this.input.keyboard
+    if (!keyboard) return
 
-      switch (event.code) {
-        case 'ArrowUp':
-        case 'KeyW':
-          dy = -1
-          break
-        case 'ArrowDown':
-        case 'KeyS':
-          dy = 1
-          break
-        case 'ArrowLeft':
-        case 'KeyA':
-          dx = -1
-          break
-        case 'ArrowRight':
-        case 'KeyD':
-          dx = 1
-          break
-        case 'Enter':
-          this.handleAction('confirm')
-          return
+    keyboard.on('keydown', (event: KeyboardEvent) => {
+      if (event.code === 'Enter') {
+        this.handleAction('confirm')
+        return
       }
+      if (DungeonScene.MOVE_KEYS.includes(event.code)) {
+        this.heldMoveKeys.add(event.code)
+        this.scheduleMove()
+      }
+    })
 
+    keyboard.on('keyup', (event: KeyboardEvent) => {
+      this.heldMoveKeys.delete(event.code)
+    })
+
+    // フォーカスを失うとkeyupを取りこぼしてキーが押しっぱなし扱いになるためクリアする
+    this.game.events.on(Phaser.Core.Events.BLUR, this.clearHeldMoveKeys, this)
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.game.events.off(Phaser.Core.Events.BLUR, this.clearHeldMoveKeys, this)
+      this.heldMoveKeys.clear()
+    })
+  }
+
+  private clearHeldMoveKeys() {
+    this.heldMoveKeys.clear()
+  }
+
+  // 同一フレーム内の複数キー押下を1回の移動にまとめ、斜め入力を取りこぼさない
+  private scheduleMove() {
+    if (this.movePending) return
+    this.movePending = true
+    requestAnimationFrame(() => {
+      this.movePending = false
+      const { dx, dy } = this.composeMoveDirection()
       if (dx !== 0 || dy !== 0) {
         this.tryMove(dx, dy)
       }
     })
+  }
+
+  // 押下中の移動キー集合から dx,dy を合成する（例: 上+右 → {dx:1, dy:-1}）
+  private composeMoveDirection(): { dx: number; dy: number } {
+    let dx = 0
+    let dy = 0
+    const keys = this.heldMoveKeys
+    if (keys.has('ArrowUp') || keys.has('KeyW')) dy -= 1
+    if (keys.has('ArrowDown') || keys.has('KeyS')) dy += 1
+    if (keys.has('ArrowLeft') || keys.has('KeyA')) dx -= 1
+    if (keys.has('ArrowRight') || keys.has('KeyD')) dx += 1
+    return { dx, dy }
   }
 
   private getUiScene() {
@@ -595,13 +634,9 @@ export class DungeonScene extends Phaser.Scene {
         exploredTiles: string[]
       ) => void
       hideMinimap: () => void
-      showInventory: (
-        inventory: { itemId: string; name: string; equipped?: boolean }[]
-      ) => void
+      showInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
       hideInventory: () => void
-      refreshInventory: (
-        inventory: { itemId: string; name: string; equipped?: boolean }[]
-      ) => void
+      refreshInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
       moveInventoryCursor: (dx: number, dy: number) => void
       getInventorySelectedIndex: () => number
     }
@@ -624,7 +659,9 @@ export class DungeonScene extends Phaser.Scene {
       return
     }
 
-    const dir = dx === -1 ? '左' : dx === 1 ? '右' : dy === -1 ? '上' : '下'
+    const h = dx === -1 ? '左' : dx === 1 ? '右' : ''
+    const v = dy === -1 ? '上' : dy === 1 ? '下' : ''
+    const dir = `${h}${v}` || '?'
     console.log(`[Move] ${dir}`)
     const result: ActionResult | null = this.gameLoop.playerMove(dx, dy)
 

--- a/tests/unit/systems/EnemyAI.test.ts
+++ b/tests/unit/systems/EnemyAI.test.ts
@@ -28,25 +28,39 @@ describe('EnemyAI', () => {
       }
     })
 
-    it('占有済みマスには移動しない', () => {
+    it('周囲8マスすべて占有済みなら移動しない', () => {
       const occupied = [
+        { x: 1, y: 1 },
         { x: 2, y: 1 },
+        { x: 3, y: 1 },
         { x: 1, y: 2 },
         { x: 3, y: 2 },
+        { x: 1, y: 3 },
         { x: 2, y: 3 },
+        { x: 3, y: 3 },
       ]
       const result = randomMove({ x: 2, y: 2 }, map, occupied)
       expect(result).toBeNull()
     })
 
-    it('移動先は隣接マス（距離1）である', () => {
+    it('移動先はChebyshev距離1（8方向の隣接）である', () => {
       const pos = { x: 2, y: 2 }
       const result = randomMove(pos, map, [])
       if (result) {
         const dx = Math.abs(result.x - pos.x)
         const dy = Math.abs(result.y - pos.y)
-        expect(dx + dy).toBe(1)
+        expect(Math.max(dx, dy)).toBe(1)
       }
+    })
+
+    it('斜めを含む8方向に移動できる', () => {
+      const seen = new Set<string>()
+      for (let i = 0; i < 300; i++) {
+        const result = randomMove({ x: 2, y: 2 }, map, [])
+        if (result) seen.add(`${result.x - 2},${result.y - 2}`)
+      }
+      const diagonals = ['-1,-1', '1,-1', '-1,1', '1,1']
+      expect(diagonals.some((d) => seen.has(d))).toBe(true)
     })
 
     it('空マップでnullを返す', () => {
@@ -56,19 +70,23 @@ describe('EnemyAI', () => {
   })
 
   describe('isAdjacent', () => {
-    it('隣接マスでtrue', () => {
+    it('縦横の隣接マスでtrue', () => {
       expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 2 })).toBe(true)
       expect(isAdjacent({ x: 2, y: 2 }, { x: 2, y: 3 })).toBe(true)
       expect(isAdjacent({ x: 2, y: 2 }, { x: 1, y: 2 })).toBe(true)
       expect(isAdjacent({ x: 2, y: 2 }, { x: 2, y: 1 })).toBe(true)
     })
 
-    it('斜めはfalse', () => {
-      expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 3 })).toBe(false)
+    it('斜めの隣接マスでもtrue（8方向）', () => {
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 3 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 1, y: 1 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 3, y: 1 })).toBe(true)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 1, y: 3 })).toBe(true)
     })
 
-    it('離れていたらfalse', () => {
+    it('Chebyshev距離2以上はfalse', () => {
       expect(isAdjacent({ x: 2, y: 2 }, { x: 4, y: 2 })).toBe(false)
+      expect(isAdjacent({ x: 2, y: 2 }, { x: 4, y: 4 })).toBe(false)
     })
 
     it('同じ位置はfalse', () => {
@@ -94,8 +112,26 @@ describe('EnemyAI', () => {
       expect(result).toEqual({ x: 1, y: 2 })
     })
 
-    it('完全に塞がれたらnull', () => {
+    it('斜め方向へ直接近づく（8方向）', () => {
+      const result = moveToward({ x: 1, y: 1 }, { x: 3, y: 3 }, map, [])
+      expect(result).toEqual({ x: 2, y: 2 })
+    })
+
+    it('壁角をすり抜けず直交方向へフォールバックする', () => {
+      // (1,1)から右下(2,2)へ行きたいが (2,1) が壁 → 斜め不可、(1,2)へ
+      const cornerMap = [
+        [1, 1, 1, 1],
+        [1, 0, 1, 1],
+        [1, 0, 0, 1],
+        [1, 1, 1, 1],
+      ]
+      const result = moveToward({ x: 1, y: 1 }, { x: 2, y: 2 }, cornerMap, [])
+      expect(result).toEqual({ x: 1, y: 2 })
+    })
+
+    it('候補マスがすべて塞がれたらnull', () => {
       const occupied = [
+        { x: 2, y: 2 },
         { x: 2, y: 1 },
         { x: 1, y: 2 },
       ]
@@ -122,6 +158,12 @@ describe('EnemyAI', () => {
     it('隣接 → attack', () => {
       const enemy = { x: 2, y: 2, type: 'skeleton', aiState: 'idle' as const }
       const action = decideAction(enemy, { x: 3, y: 2 }, map, [])
+      expect(action.type).toBe('attack')
+    })
+
+    it('斜め隣接 → attack（8方向攻撃）', () => {
+      const enemy = { x: 2, y: 2, type: 'skeleton', aiState: 'chase' as const }
+      const action = decideAction(enemy, { x: 3, y: 3 }, map, [])
       expect(action.type).toBe('attack')
     })
 

--- a/tests/unit/systems/movement.test.ts
+++ b/tests/unit/systems/movement.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { canMoveDiagonally } from '../../../game/systems/movement'
+
+// 0=床, 1=壁
+describe('canMoveDiagonally (壁角すり抜け禁止)', () => {
+  it('直交移動（dx=0 または dy=0）は常に許可', () => {
+    const map = [
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+    ]
+    expect(canMoveDiagonally(map, 1, 1, 0, -1)).toBe(true)
+    expect(canMoveDiagonally(map, 1, 1, 1, 0)).toBe(true)
+  })
+
+  it('両隣接直交マスが床なら斜め移動を許可', () => {
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ]
+    expect(canMoveDiagonally(map, 1, 1, 1, 1)).toBe(true)
+    expect(canMoveDiagonally(map, 1, 1, -1, -1)).toBe(true)
+    expect(canMoveDiagonally(map, 1, 1, 1, -1)).toBe(true)
+    expect(canMoveDiagonally(map, 1, 1, -1, 1)).toBe(true)
+  })
+
+  it('横隣が壁なら斜め移動を禁止', () => {
+    // (1,1)から右下(2,2)へ。右(2,1)が壁
+    const map = [
+      [0, 0, 0],
+      [0, 0, 1],
+      [0, 0, 0],
+    ]
+    expect(canMoveDiagonally(map, 1, 1, 1, 1)).toBe(false)
+  })
+
+  it('縦隣が壁なら斜め移動を禁止', () => {
+    // (1,1)から右下(2,2)へ。下(1,2)が壁
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 1, 0],
+    ]
+    expect(canMoveDiagonally(map, 1, 1, 1, 1)).toBe(false)
+  })
+
+  it('両隣接直交マスが壁なら斜め移動を禁止', () => {
+    // (1,1)から左上(0,0)へ。上(1,0)と左(0,1)が壁
+    const map = [
+      [0, 1, 0],
+      [1, 0, 0],
+      [0, 0, 0],
+    ]
+    expect(canMoveDiagonally(map, 1, 1, -1, -1)).toBe(false)
+  })
+
+  it('範囲外は壁扱いで斜め移動を禁止', () => {
+    const map = [
+      [0, 0],
+      [0, 0],
+    ]
+    // (0,0)から左上(-1,-1)へ。隣接マスが範囲外
+    expect(canMoveDiagonally(map, 0, 0, -1, -1)).toBe(false)
+  })
+
+  it('空マップは常に禁止（安全側）', () => {
+    expect(canMoveDiagonally([], 0, 0, 1, 1)).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概要

プレイヤー・敵の移動を4方向から8方向（斜め含む）へ拡張する。Closes #13

## 変更内容

- **`game/systems/movement.ts`（新規）**: 純粋関数 `canMoveDiagonally(map, fromX, fromY, dx, dy)` を追加。斜め移動時、隣接する2つの直交マスのいずれかが壁（範囲外含む）なら斜め移動を禁止する「壁角すり抜け(corner-cut)禁止」ルール。
- **キーボード8方向化（`phaser/scenes/DungeonScene.ts`）**: 押下中の移動キー集合から dx,dy を合成する方式へ変更（矢印/WASD 両対応、上+右 同時押しで右上へ）。`requestAnimationFrame` で同一フレーム内の複数キー押下を1回の移動にまとめ、斜め入力の取りこぼしを防止。フォーカス喪失時はキー集合をクリア。Enter=攻撃/決定は従来どおり。移動ログも斜め表記に対応。
- **`game/systems/EnemyAI.ts` 8方向化**: `DIRECTIONS` を8方向に拡張。`isAdjacent` を Chebyshev 距離1（斜め隣接も true）に。`moveToward` を8方向貪欲（斜め優先→直交フォールバック）に。`randomMove`/`moveToward` とも corner-cut を尊重（共通ヘルパ `canEnter` に集約）。
- **斜め攻撃**: プレイヤーの `direction` が斜めを保持できるため、既存の攻撃対象算出（`useGameLoop` の position+direction）がそのまま斜め攻撃に対応。敵も斜め隣接で攻撃が成立。
- **corner-cut を `useGameLoop.playerMove` にも適用**。

## 設計判断

- corner-cut 禁止は `randomMove` にも適用（敵が壁角を斜めにすり抜けないよう一貫性を確保）。
- 斜め攻撃自体は壁角チェックを課さず、Chebyshev 距離1で成立させる（issue の要件どおりシンプルに）。占有マス（他エンティティ）は corner-cut を阻害しない（壁のみが阻害）。

## テスト

- `tests/unit/systems/movement.test.ts`（新規）: 直交は常に許可 / 両隣床で許可 / 横・縦・両隣が壁で禁止 / 範囲外禁止 / 空マップ禁止。
- `tests/unit/systems/EnemyAI.test.ts`: 斜め `isAdjacent`、8方向 `randomMove`（Chebyshev距離1・斜め出現・周囲8マス占有でnull）、`moveToward` の斜め移動/corner-cutフォールバック/全塞ぎnull、斜め隣接attack を追加・更新（4方向前提のアサーションを8方向仕様へ更新）。
- `npm run test`: 10ファイル 140件 グリーン。`eslint .` エラーなし。

## 検証手順（手動）

1. `npm run dev` で起動し、矢印/WASD で上+右などを同時に押下 → 斜めに移動できる。
2. 壁の凸角に向かって斜め入力 → 斜めにすり抜けられない（直交側が壁なら止まる）。
3. 敵と斜めに隣接した状態で、その方向へ攻撃 → 命中する。敵も斜め隣接からプレイヤーを攻撃する。
4. 既存の4方向移動・攻撃が従来どおり動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 斜め移動時に壁の角をすり抜けられないようになりました。
  * プレイヤーと敵が8方向へ移動・攻撃できるようになり、より自然な経路を選択します。
  * 複数キーによる斜め入力が安定して認識されます。
  * アイテム画像が見つからない場合の表示が改善されました。

* **バグ修正**
  * 壁や障害物に囲まれた場所で、敵が不正に移動する問題を修正しました。

* **テスト**
  * 斜め移動、敵の移動・攻撃判定に関するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->