### PR TITLE
feat(m4): 拠点基盤 — 村・gold永続化・脱出コア

### DIFF
--- a/components/GameCanvas.client.vue
+++ b/components/GameCanvas.client.vue
@@ -44,7 +44,14 @@
       gameLoop.initDungeon(gameStore.dungeon.dungeonId)
     }
 
-    // 復元時にゲーム終了状態ならリザルトへ直接遷移
+    // 拠点の永続データ（gold等）は localStorage を正として同期（session復元より優先）
+    gameStore.loadMeta()
+
+    // 復元時にゲーム終了状態ならリザルト/拠点へ直接遷移
+    if (gameStore.gameResult === 'escaped') {
+      router.replace('/village')
+      return
+    }
     if (gameStore.gameResult !== 'active') {
       router.replace('/gameover')
       return
@@ -55,11 +62,13 @@
       gameStore.saveToSession()
     })
 
-    // ゲームオーバー・クリア時にリザルト画面へ遷移
+    // ゲーム終了時に画面遷移: 脱出→拠点、死亡/クリア→リザルト
     watch(
       () => gameStore.gameResult,
       (result) => {
-        if (result === 'dead' || result === 'cleared') {
+        if (result === 'escaped') {
+          router.push('/village')
+        } else if (result === 'dead' || result === 'cleared') {
           router.push('/gameover')
         }
       }

--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -389,6 +389,20 @@ export function useGameLoop() {
     initFloor(1)
   }
 
+  // ダンジオンから脱出して拠点へ戻る。現ランのゴールドは拠点に持ち帰る。
+  function escapeDungeon() {
+    const carried = store.player.gold
+    store.setLastRun({
+      result: 'escaped',
+      goldBanked: carried,
+      goldLost: 0,
+      floor: store.dungeon.floor,
+    })
+    store.bankRunGold()
+    // gameResult の変化を GameCanvas が監視して /village へ遷移する
+    store.setGameResult('escaped')
+  }
+
   function goNextFloor(): string[] | { cleared: true; messages: string[] } {
     const { floor, totalFloors } = store.dungeon
 
@@ -416,5 +430,6 @@ export function useGameLoop() {
     initFloor,
     initDungeon,
     goNextFloor,
+    escapeDungeon,
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,6 +7,10 @@
     router.push('/game')
   }
 
+  const goVillage = () => {
+    router.push('/village')
+  }
+
   const continueGame = () => {
     // TODO: セーブデータ読み込み
     router.push('/game')
@@ -27,6 +31,7 @@
     <!-- メニューボタン -->
     <div class="menu nes-container is-dark is-rounded">
       <button class="nes-btn is-primary menu-btn" @click="startGame">はじめから</button>
+      <button class="nes-btn menu-btn" @click="goVillage">きょてんへ</button>
       <button
         class="nes-btn menu-btn"
         :class="{ 'is-disabled': !hasSaveData }"

--- a/pages/village.vue
+++ b/pages/village.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue'
+  import { useGameStore } from '~/stores/gameStore'
+  import { DUNGEONS, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
+
+  // 拠点画面（村）: 脱出・帰還の行き先、永続ゴールドの表示、ダンジョンへの出発
+  const router = useRouter()
+  const gameStore = useGameStore()
+
+  const gold = computed(() => gameStore.meta.gold)
+  const lastRun = computed(() => gameStore.meta.lastRun)
+
+  const lastRunLabel = computed(() => {
+    const r = lastRun.value
+    if (!r) return ''
+    if (r.result === 'escaped') return '生還'
+    if (r.result === 'cleared') return '踏破'
+    return '力尽きた'
+  })
+
+  const dungeonList = computed(() =>
+    Object.values(DUNGEONS).map((d) => ({
+      id: d.id,
+      name: d.name,
+      floors: d.floors.length,
+    }))
+  )
+
+  const selectedDungeonId = ref(DEFAULT_DUNGEON_ID)
+
+  onMounted(() => {
+    // localStorage から永続データを同期
+    gameStore.loadMeta()
+  })
+
+  const departDungeon = () => {
+    const dungeon = DUNGEONS[selectedDungeonId.value] ?? DUNGEONS[DEFAULT_DUNGEON_ID]
+    // 選択したダンジョンをストアに設定し、現ランのセッションを破棄して新規開始
+    gameStore.setDungeon(dungeon.id, dungeon.floors.length)
+    sessionStorage.removeItem('gameState')
+    router.push('/game')
+  }
+
+  const backToTitle = () => {
+    router.push('/')
+  }
+</script>
+
+<template>
+  <div class="village-screen">
+    <div class="header-area">
+      <h1 class="title">拠点の村</h1>
+      <p class="subtitle nes-text is-disabled">〜 深淵の入口 〜</p>
+    </div>
+
+    <!-- 所持金 -->
+    <div class="gold-panel nes-container is-dark is-rounded">
+      <div class="gold-row">
+        <span class="gold-label">所持金</span>
+        <span class="gold-value">{{ gold }} G</span>
+      </div>
+      <p v-if="lastRun" class="lastrun" :class="`is-${lastRun.result}`">
+        前回: {{ lastRunLabel }} / B{{ lastRun.floor }}F
+        <template v-if="lastRun.goldBanked > 0"> ・ +{{ lastRun.goldBanked }}G</template>
+        <template v-if="lastRun.goldLost > 0"> ・ -{{ lastRun.goldLost }}G</template>
+      </p>
+    </div>
+
+    <!-- 鍛冶（PR4で中身を実装するプレースホルダ） -->
+    <div class="shop-panel nes-container is-dark is-rounded">
+      <p class="shop-title">鍛冶屋</p>
+      <p class="shop-note nes-text is-disabled">まだ準備中だ…（近日開放）</p>
+    </div>
+
+    <!-- ダンジョンへ出発 -->
+    <div class="depart-panel nes-container is-dark is-rounded">
+      <p class="depart-title">どこへ潜る？</p>
+      <div class="dungeon-list">
+        <label
+          v-for="d in dungeonList"
+          :key="d.id"
+          class="dungeon-option"
+          :class="{ 'is-selected': selectedDungeonId === d.id }"
+        >
+          <input v-model="selectedDungeonId" type="radio" :value="d.id" class="nes-radio" />
+          <span class="dungeon-name">{{ d.name }}</span>
+          <span class="dungeon-floors">B{{ d.floors }}F</span>
+        </label>
+      </div>
+      <button class="nes-btn is-primary depart-btn" @click="departDungeon">ダンジョンへ出発</button>
+    </div>
+
+    <div class="menu">
+      <button class="nes-btn menu-btn" @click="backToTitle">タイトルへ</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .village-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 1.2rem;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background-color: #1a1a2e;
+    color: #fff;
+    padding: 2rem 1rem;
+    font-family: 'DotGothic16', monospace;
+  }
+
+  .header-area {
+    text-align: center;
+  }
+
+  .title {
+    font-size: 1.4rem;
+    margin: 0 0 0.3rem;
+  }
+
+  .subtitle {
+    font-size: 0.6rem;
+    margin: 0;
+  }
+
+  .gold-panel,
+  .shop-panel,
+  .depart-panel {
+    width: 100%;
+    max-width: 320px;
+    padding: 1rem !important;
+  }
+
+  .gold-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 0.85rem;
+  }
+
+  .gold-value {
+    color: #ffd700;
+    font-weight: bold;
+  }
+
+  .lastrun {
+    margin: 0.6rem 0 0;
+    font-size: 0.6rem;
+    opacity: 0.85;
+  }
+
+  .lastrun.is-escaped,
+  .lastrun.is-cleared {
+    color: #7fdfa0;
+  }
+
+  .lastrun.is-dead {
+    color: #ff8a8a;
+  }
+
+  .shop-title,
+  .depart-title {
+    font-size: 0.75rem;
+    margin: 0 0 0.6rem;
+  }
+
+  .shop-note {
+    font-size: 0.6rem;
+    margin: 0;
+  }
+
+  .dungeon-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.9rem;
+  }
+
+  .dungeon-option {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+  }
+
+  .dungeon-name {
+    flex: 1;
+  }
+
+  .dungeon-floors {
+    opacity: 0.7;
+    font-size: 0.6rem;
+  }
+
+  .dungeon-option.is-selected .dungeon-name {
+    color: #ffd700;
+  }
+
+  .depart-btn {
+    width: 100%;
+    padding: 0.7rem 1rem !important;
+    font-size: 0.75rem !important;
+  }
+
+  .menu {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .menu-btn {
+    width: 100%;
+    padding: 0.6rem 1rem !important;
+    font-size: 0.7rem !important;
+  }
+
+  @media (min-width: 480px) {
+    .title {
+      font-size: 1.8rem;
+    }
+
+    .gold-row {
+      font-size: 1rem;
+    }
+  }
+</style>

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -58,7 +58,24 @@ interface DungeonState {
   totalFloors: number
 }
 
-export type GameResult = 'active' | 'dead' | 'cleared'
+export type GameResult = 'active' | 'dead' | 'cleared' | 'escaped'
+
+// 直近1ランのリザルト（拠点画面で表示する）
+interface LastRun {
+  result: 'escaped' | 'dead' | 'cleared'
+  goldBanked: number // 拠点に預けたゴールド
+  goldLost: number // 死亡ペナルティ等で失ったゴールド
+  floor: number // 到達フロア
+}
+
+// ラン跨ぎで永続する拠点データ（localStorage 保存）
+interface MetaState {
+  gold: number // 拠点に預けた永続ゴールド（鍛冶で使用）
+  lastRun: LastRun | null
+}
+
+// localStorage キー（sessionStorage の現ラン継続とは別レイヤ）
+const META_STORAGE_KEY = 'katabasis_meta'
 
 interface GameState {
   player: PlayerState
@@ -73,6 +90,7 @@ interface GameState {
   gameResult: GameResult
   defeatedEnemies: number
   maxFloorReached: number
+  meta: MetaState // ラン跨ぎ永続データ
 }
 
 export const useGameStore = defineStore('game', {
@@ -106,6 +124,10 @@ export const useGameStore = defineStore('game', {
     gameResult: 'active',
     defeatedEnemies: 0,
     maxFloorReached: 1,
+    meta: {
+      gold: 0,
+      lastRun: null,
+    },
   }),
 
   getters: {
@@ -179,7 +201,48 @@ export const useGameStore = defineStore('game', {
     },
 
     resetGame() {
+      // meta（永続ゴールド等）はランを跨いで保持する
+      const preservedMeta: MetaState = JSON.parse(JSON.stringify(this.meta))
       this.$reset()
+      this.meta = preservedMeta
+    },
+
+    // --- 拠点永続データ（localStorage レイヤ） ---
+
+    persistMeta() {
+      if (typeof localStorage === 'undefined') return
+      localStorage.setItem(META_STORAGE_KEY, JSON.stringify(this.meta))
+    },
+
+    loadMeta(): boolean {
+      if (typeof localStorage === 'undefined') return false
+      const saved = localStorage.getItem(META_STORAGE_KEY)
+      if (!saved) return false
+      try {
+        const parsed = JSON.parse(saved)
+        this.meta = {
+          gold: typeof parsed.gold === 'number' ? parsed.gold : 0,
+          lastRun: parsed.lastRun ?? null,
+        }
+        return true
+      } catch {
+        localStorage.removeItem(META_STORAGE_KEY)
+        return false
+      }
+    },
+
+    // 現ランで稼いだゴールドを拠点（永続）ゴールドへ預ける
+    bankRunGold(): number {
+      const amount = this.player.gold
+      this.meta.gold += amount
+      this.player.gold = 0
+      this.persistMeta()
+      return amount
+    },
+
+    setLastRun(info: LastRun) {
+      this.meta.lastRun = info
+      this.persistMeta()
     },
 
     addMessage(message: string) {
@@ -245,17 +308,14 @@ export const useGameStore = defineStore('game', {
 
       // ゴールドはプレイヤーの所持金に加算
       if (def.type === 'gold') {
-        const goldAmount =
-          amount > 1 ? amount : gameConfig.goldConfig?.defaultDropAmount ?? 10
+        const goldAmount = amount > 1 ? amount : (gameConfig.goldConfig?.defaultDropAmount ?? 10)
         this.player.gold += goldAmount
         return { message: `${goldAmount}Gを拾った！`, toGold: true }
       }
 
       // スタック可能アイテムは既存スタックに合算
       if (def.stackable) {
-        const existing = this.inventory.find(
-          (i) => i.itemId === itemId && !i.equipped
-        )
+        const existing = this.inventory.find((i) => i.itemId === itemId && !i.equipped)
         if (existing) {
           existing.stack = (existing.stack ?? 1) + amount
           return { message: `${def.name}を拾った！`, toGold: false }


### PR DESCRIPTION
## 概要

M4（アイテム・経済系）の共通土台となる **拠点基盤** を実装。これは **#35（装備強化・鍛冶）と #37（死亡ペナルティ・脱出）の土台** となる enabler PR（単独 issue には紐づかない）。

## 変更内容

- **拠点画面 `pages/village.vue`**（簡易村）
  - 永続ゴールド（拠点gold）の表示
  - 前回ランのリザルトバナー（生還/踏破/力尽きた + 増減G）
  - ダンジョン選択 → 「ダンジョンへ出発」
  - 鍛冶屋プレースホルダ（中身は #35 で実装）
- **localStorage 永続化層**（`stores/gameStore.ts`）
  - `meta { gold, lastRun }` を state に追加（sessionStorage の現ラン継続とは別キー `katabasis_meta`）
  - `persistMeta()` / `loadMeta()`、`resetGame()` は meta を保持
  - `bankRunGold()`: 現ランで稼いだ `player.gold` を拠点 `meta.gold` へ移動
- **脱出コア** `composables/useGameLoop.ts` に `escapeDungeon()`（gold 持ち帰り → `gameResult='escaped'`）
- **遷移** `GameCanvas.client.vue`: `escaped` を監視して `/village` へ push、`loadMeta()` で localStorage を正として同期
- **導線** タイトルに「きょてんへ」ボタンを追加（既存の title→game は維持）

## 設計判断

- gold は2層管理: **ランgold（`player.gold`, sessionStorage）** と **拠点gold（`meta.gold`, localStorage永続）** を分離。ランgoldは脱出時に拠点goldへ預ける（`bankRunGold`）。`resetGame`（$reset）でランgoldが0化しても拠点goldは別レイヤなので消えない。
- 脱出後のリザルトは拠点画面のバナーで表示（`meta.lastRun`）。

## 検証

- `npx eslint .` パス（0 errors）
- `npm run test` パス（129 tests）
- 拠点画面が表示され gold が出る／出発でダンジョン開始（脱出導線の接続は #37 の PR で）

> 注: `npm run lint` の markdownlint は worktree の `node_modules` シンボリックリンク解決の副作用で node_modules 内 README を拾い失敗するが、プロジェクトのコード（eslint）・md は clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)