### PR TITLE
feat(m4): 死亡ペナルティ・ダンジョン脱出 (#37)

### DIFF
--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -47,6 +47,9 @@
     "dropVariance": 7,
     "dropChance": 0.6
   },
+  "deathPenalty": {
+    "goldLossRate": 1.0
+  },
   "dungeonConfig": {
     "floorsTotal": 10,
     "enemiesPerFloor": [3, 4, 5, 6, 7, 8, 9, 10, 12, 15]

--- a/game/systems/EconomySystem.ts
+++ b/game/systems/EconomySystem.ts
@@ -1,0 +1,16 @@
+// 経済系の純粋計算（Phaser 非依存・テスト可能）
+
+// 死亡時のゴールドロスト計算。
+// runGold: 現ランで所持しているゴールド
+// lossRate: 失う割合（0=ロストなし, 1=全ロスト）。範囲外は 0..1 にクランプ。
+// 戻り値: 失う額 lost と 拠点へ持ち帰る額 kept（合計は元の runGold）
+export function computeDeathGoldLoss(
+  runGold: number,
+  lossRate: number
+): { lost: number; kept: number } {
+  const gold = Math.max(0, Math.floor(runGold))
+  const rate = Math.min(1, Math.max(0, lossRate))
+  const lost = Math.floor(gold * rate)
+  const kept = gold - lost
+  return { lost, kept }
+}

--- a/pages/gameover.vue
+++ b/pages/gameover.vue
@@ -15,12 +15,24 @@
   const finalLevel = computed(() => gameStore.player.level)
   const defeatedCount = computed(() => gameStore.defeatedEnemies)
 
+  // gold のリザルト（死亡=ロスト額 / 踏破=持ち帰り額）
+  const goldLost = computed(() => gameStore.meta.lastRun?.goldLost ?? 0)
+  const goldBanked = computed(() => gameStore.meta.lastRun?.goldBanked ?? 0)
+  const goldLabel = computed(() => (isDead.value ? '失ったゴールド' : '持ち帰ったゴールド'))
+  const goldValue = computed(() => (isDead.value ? goldLost.value : goldBanked.value))
+
   onMounted(() => {
     // 不正遷移対策: activeのままならタイトルへ戻す
     if (gameStore.gameResult === 'active') {
       router.replace('/')
     }
   })
+
+  const backToVillage = () => {
+    sessionStorage.removeItem('gameState')
+    gameStore.resetGame() // meta（永続gold）は保持される
+    router.push('/village')
+  }
 
   const backToTitle = () => {
     sessionStorage.removeItem('gameState')
@@ -50,11 +62,16 @@
           <dt>撃破数</dt>
           <dd>{{ defeatedCount }}</dd>
         </div>
+        <div class="stat-row">
+          <dt>{{ goldLabel }}</dt>
+          <dd :class="{ 'gold-lost': isDead, 'gold-kept': !isDead }">{{ goldValue }} G</dd>
+        </div>
       </dl>
     </div>
 
     <div class="menu">
-      <button class="nes-btn is-primary menu-btn" @click="backToTitle">タイトルへ</button>
+      <button class="nes-btn is-primary menu-btn" @click="backToVillage">拠点へもどる</button>
+      <button class="nes-btn menu-btn" @click="backToTitle">タイトルへ</button>
     </div>
   </div>
 </template>
@@ -134,9 +151,20 @@
     font-weight: bold;
   }
 
+  .stat-row dd.gold-lost {
+    color: #ff8a8a;
+  }
+
+  .stat-row dd.gold-kept {
+    color: #ffd700;
+  }
+
   .menu {
     width: 100%;
     max-width: 280px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
   }
 
   .menu-btn {

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -497,7 +497,8 @@ export class DungeonScene extends Phaser.Scene {
       const x = this.offsetX + screenTileX * this.tileWidth + this.tileWidth / 2
       const y = this.offsetY + screenTileY * this.tileHeight + this.tileHeight / 2
       const def = ITEMS[item.itemId]
-      const spriteKey = def?.sprite && this.textures.exists(def.sprite) ? def.sprite : 'weapon_sword'
+      const spriteKey =
+        def?.sprite && this.textures.exists(def.sprite) ? def.sprite : 'weapon_sword'
       const sprite = this.add.image(x, y, spriteKey)
       // 専用スプライト (flask 等) は元画像が小さいので大きめに描画する
       const scaleFactor = spriteKey === 'weapon_sword' ? 0.35 : 0.55
@@ -595,13 +596,9 @@ export class DungeonScene extends Phaser.Scene {
         exploredTiles: string[]
       ) => void
       hideMinimap: () => void
-      showInventory: (
-        inventory: { itemId: string; name: string; equipped?: boolean }[]
-      ) => void
+      showInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
       hideInventory: () => void
-      refreshInventory: (
-        inventory: { itemId: string; name: string; equipped?: boolean }[]
-      ) => void
+      refreshInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
       moveInventoryCursor: (dx: number, dy: number) => void
       getInventorySelectedIndex: () => number
     }
@@ -697,6 +694,10 @@ export class DungeonScene extends Phaser.Scene {
             )
           } else if (selected === '道具') {
             ui.showInventory(this.gameStore.inventory)
+          } else if (selected === '脱出') {
+            ui.showConfirm('ダンジョンから脱出しますか？', () => {
+              this.gameLoop.escapeDungeon()
+            })
           } else {
             this.updateUI([`${selected}（未実装）`])
           }
@@ -847,8 +848,9 @@ export class DungeonScene extends Phaser.Scene {
     this.inputLocked = true
     this.stopBgm()
     this.playSE('se_game_over')
-    // 持ち物全ロスト (issue #7)
+    // 持ち物全ロスト (issue #7) + gold ロスト (死亡ペナルティ, issue #37)
     this.gameStore.clearInventory()
+    this.gameStore.applyDeathPenalty()
 
     // プレイヤー位置に赤フラッシュ
     const playerPos = this.gameStore.player.position
@@ -1052,6 +1054,14 @@ export class DungeonScene extends Phaser.Scene {
       ease: 'Power2',
       onComplete: () => {
         this.time.delayedCall(1500, () => {
+          // 踏破は生還扱い: 現ランgoldを拠点へ持ち帰る (issue #37)
+          const banked = this.gameStore.bankRunGold()
+          this.gameStore.setLastRun({
+            result: 'cleared',
+            goldBanked: banked,
+            goldLost: 0,
+            floor: this.gameStore.dungeon.floor,
+          })
           this.gameStore.setGameResult('cleared')
           overlay.destroy()
         })

--- a/phaser/ui/MenuOverlay.ts
+++ b/phaser/ui/MenuOverlay.ts
@@ -28,7 +28,7 @@ export class MenuOverlay {
     const overlay = scene.add.rectangle(240, overlayY + overlayH / 2, 480, overlayH, 0x000000, 0.6)
     this.container.add(overlay)
 
-    // 左上: メニューボタン（道具/マップ/足元/作戦）
+    // 左上: メニューボタン（道具/マップ/足元/脱出）
     const menuBg = scene.add.graphics()
     menuBg.fillStyle(UI_COLOR.panelBg, 0.95)
     menuBg.fillRoundedRect(8, 56, 170, 76, 6)
@@ -40,7 +40,7 @@ export class MenuOverlay {
       { text: '道具', col: 0, row: 0 },
       { text: 'マップ', col: 1, row: 0 },
       { text: '足元', col: 0, row: 1 },
-      { text: '作戦', col: 1, row: 1 },
+      { text: '脱出', col: 1, row: 1 },
     ]
 
     const menuStyle = { ...BASE_STYLE, color: TEXT_COLOR.muted }

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -5,6 +5,7 @@ import {
   equipItem as calcEquip,
   unequipItem as calcUnequip,
 } from '~/game/systems/ItemSystem'
+import { computeDeathGoldLoss } from '~/game/systems/EconomySystem'
 import gameConfig from '~/game/data/gameConfig.json'
 
 interface PlayerState {
@@ -243,6 +244,21 @@ export const useGameStore = defineStore('game', {
     setLastRun(info: LastRun) {
       this.meta.lastRun = info
       this.persistMeta()
+    },
+
+    // 死亡時のペナルティ適用: 現ランgoldの一定割合をロスト、残りは拠点へ持ち帰る
+    applyDeathPenalty(): { lost: number; kept: number } {
+      const rate = gameConfig.deathPenalty?.goldLossRate ?? 1
+      const { lost, kept } = computeDeathGoldLoss(this.player.gold, rate)
+      this.meta.gold += kept
+      this.player.gold = 0
+      this.setLastRun({
+        result: 'dead',
+        goldBanked: kept,
+        goldLost: lost,
+        floor: this.dungeon.floor,
+      })
+      return { lost, kept }
     },
 
     addMessage(message: string) {

--- a/tests/unit/systems/EconomySystem.test.ts
+++ b/tests/unit/systems/EconomySystem.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { computeDeathGoldLoss } from '../../../game/systems/EconomySystem'
+
+describe('EconomySystem.computeDeathGoldLoss', () => {
+  it('lossRate=1 で全ロスト', () => {
+    const { lost, kept } = computeDeathGoldLoss(100, 1)
+    expect(lost).toBe(100)
+    expect(kept).toBe(0)
+  })
+
+  it('lossRate=0 でロストなし', () => {
+    const { lost, kept } = computeDeathGoldLoss(100, 0)
+    expect(lost).toBe(0)
+    expect(kept).toBe(100)
+  })
+
+  it('lossRate=0.5 で半分ロスト（端数は切り捨て）', () => {
+    const { lost, kept } = computeDeathGoldLoss(101, 0.5)
+    expect(lost).toBe(50)
+    expect(kept).toBe(51)
+  })
+
+  it('lost + kept は常に元の額に一致', () => {
+    for (const gold of [0, 1, 7, 33, 250]) {
+      for (const rate of [0, 0.25, 0.5, 0.9, 1]) {
+        const { lost, kept } = computeDeathGoldLoss(gold, rate)
+        expect(lost + kept).toBe(Math.floor(gold))
+      }
+    }
+  })
+
+  it('負のgoldは0扱い', () => {
+    const { lost, kept } = computeDeathGoldLoss(-50, 1)
+    expect(lost).toBe(0)
+    expect(kept).toBe(0)
+  })
+
+  it('lossRateが範囲外でも 0..1 にクランプ', () => {
+    expect(computeDeathGoldLoss(100, 2).lost).toBe(100)
+    expect(computeDeathGoldLoss(100, -1).lost).toBe(0)
+  })
+})


### PR DESCRIPTION
## 概要

**#37 死亡ペナルティ・ダンジョン脱出** を実装。拠点基盤 PR (#62) の上にスタック。

> base: `feat/m4-base-camp` (#62)

## 変更内容

### 脱出（任意帰還）
- ゲーム内メニューの未実装枠「作戦」を **「脱出」** に置換（`MenuOverlay.ts`）
- メニュー→「脱出」→確認ダイアログ→ `escapeDungeon()`（拠点基盤で追加済）で拠点へ帰還。現ランの gold を全額持ち帰る。

### 死亡ペナルティ
- `game/data/gameConfig.json` に `deathPenalty.goldLossRate`（既定 **1.0 = 全ロスト**、調整可能）を追加
- 純粋計算 `game/systems/EconomySystem.computeDeathGoldLoss(runGold, lossRate)` を新設（`lost`/`kept` を返す・端数切り捨て・クランプ）→ 単体テスト追加
- `gameStore.applyDeathPenalty()`: 上記で算出した `kept` を拠点goldへ、`lastRun` に death を記録。死亡時は既存の持ち物ロスト（`clearInventory`）に加えて実行。

### 踏破(cleared)
- 踏破も生還扱いとし、`bankRunGold()` で gold を拠点へ持ち帰り + `lastRun` 記録。

### リザルト画面
- `gameover.vue`: 死亡=「失ったゴールド」/踏破=「持ち帰ったゴールド」を出し分け表示。主ボタンを **「拠点へもどる」→ /village**（meta保持）に、副ボタンで従来の「タイトルへ」。

## 設計判断

- **gold は2層**: ランgold(`player.gold`)は死亡で失うリスク資産、拠点gold(`meta.gold`)は脱出/踏破で預けた安全資産。銀行に預けた拠点goldは死亡でも減らない（`goldLossRate` は現ランgoldにのみ適用）。これによりローグライクの「脱出して稼ぎを守る/死んで失う」ループが成立。
- **死亡→gameover→拠点、脱出→拠点直行**: 死亡は演出(gameover)を経て拠点へ、脱出は即拠点へ。いずれも `meta.lastRun` を拠点/リザルトで表示。

## 検証

- `npx eslint .` パス（0 errors。village.vue に prettier 由来の void要素 self-closing warning が1件出るが非ブロッキング）
- `npm run test` パス（**135 tests**、EconomySystem 6件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)