### PR TITLE
feat: FOV視界システム (#12)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -290,7 +290,7 @@ export function useGameLoop() {
     }
 
     store.setPlayerPosition(newX, newY)
-    store.revealAround(newX, newY)
+    store.recomputeFov(newX, newY)
 
     const item = store.floorItems.find((i) => i.x === newX && i.y === newY)
     if (item) {
@@ -382,7 +382,7 @@ export function useGameLoop() {
     store.clearFloorItems()
     store.clearExplored()
     turnManager.reset()
-    store.revealAround(generated.playerStart.x, generated.playerStart.y)
+    store.recomputeFov(generated.playerStart.x, generated.playerStart.y)
 
     for (const item of generated.items) {
       store.addFloorItem(item)

--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -14,6 +14,7 @@
     "defense": 5,
     "dodge": 0.05,
     "viewRange": 6,
+    "fovEnabled": true,
     "initialGold": 0
   },
   "enemyTypes": {

--- a/game/systems/FOVSystem.ts
+++ b/game/systems/FOVSystem.ts
@@ -1,0 +1,42 @@
+import { FOV } from 'rot-js'
+import { TILE } from '../data/maps'
+
+/**
+ * プレイヤー視点からの可視タイル集合を計算する（純粋関数・Phaser非依存）。
+ *
+ * rot-js の PreciseShadowcasting (topology 8) を用いて 360度の視界を計算する。
+ * 壁は光を通さない（＝その先を遮る）が、壁そのものは「見えている」タイルとして
+ * 可視集合に含める（壁面の描画のため）。
+ *
+ * @param map   マップ（0=床 / 2=階段=光を通す, 1=壁=遮る）
+ * @param x     視点 X（プレイヤー）
+ * @param y     視点 Y（プレイヤー）
+ * @param range 視界半径（Chebyshev距離）
+ * @returns "x,y" 形式の可視座標の Set
+ */
+export function computeVisible(map: number[][], x: number, y: number, range: number): Set<string> {
+  const visible = new Set<string>()
+  if (map.length === 0 || map[0].length === 0) return visible
+
+  const height = map.length
+  const width = map[0].length
+
+  const inBounds = (px: number, py: number): boolean =>
+    px >= 0 && px < width && py >= 0 && py < height
+
+  // 光が通る = マップ範囲内かつ壁でない
+  const lightPasses = (px: number, py: number): boolean => {
+    if (!inBounds(px, py)) return false
+    return map[py][px] !== TILE.WALL
+  }
+
+  const fov = new FOV.PreciseShadowcasting(lightPasses, { topology: 8 })
+  // compute のコールバックは可視セル（visibility > 0）に対してのみ呼ばれる
+  fov.compute(x, y, range, (cx: number, cy: number) => {
+    if (inBounds(cx, cy)) {
+      visible.add(`${cx},${cy}`)
+    }
+  })
+
+  return visible
+}

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser'
 import { TILE } from '../../game/data/maps'
 import { getDungeon } from '../../game/dungeon'
 import { ITEMS } from '../../game/data/items'
+import gameConfig from '../../game/data/gameConfig.json'
 import type { CombatEvent, ActionResult } from '../../composables/useGameLoop'
 
 const ITEM_TINT: Record<string, number> = {
@@ -12,6 +13,11 @@ const ITEM_TINT: Record<string, number> = {
   gold: 0xffd700,
   other: 0xcccccc,
 }
+
+// 探索済みだが今は見えていないタイルの減光色（乗算tint）
+const DIM_TINT = 0x555566
+
+type TileVisibility = 'visible' | 'explored' | 'hidden'
 
 export class DungeonScene extends Phaser.Scene {
   // 表示するタイル数（ビューポート）
@@ -66,6 +72,11 @@ export class DungeonScene extends Phaser.Scene {
   // キーボード8方向移動: 押下中の移動キー集合と、1フレーム内の移動合成フラグ
   private heldMoveKeys = new Set<string>()
   private movePending = false
+
+  // FOV（視界）: 有効フラグと、drawScene 内で使い回す可視/探索済み集合
+  private fovActive = false
+  private visibleSet: Set<string> = new Set()
+  private exploredSet: Set<string> = new Set()
 
   // BGM
   private currentBgm: Phaser.Sound.BaseSound | null = null
@@ -138,6 +149,16 @@ export class DungeonScene extends Phaser.Scene {
     this.calculateTileSize()
 
     this.syncMapFromStore()
+
+    // FOV有効判定: playerConfig.fovEnabled（既定ON）または debugConfig.showFOV（強制ON）
+    const playerCfg = gameConfig.playerConfig as { fovEnabled?: boolean }
+    const debugCfg = gameConfig.debugConfig as { showFOV?: boolean }
+    this.fovActive = (playerCfg?.fovEnabled ?? false) || (debugCfg?.showFOV ?? false)
+
+    // マウント／リロード直後に可視タイルが空でも即描画できるよう再計算する
+    if (this.fovActive) {
+      this.gameStore.recomputeFov()
+    }
 
     // コンテナ作成（描画順序制御用）
     this.floorContainer = this.add.container(0, 0)
@@ -323,6 +344,12 @@ export class DungeonScene extends Phaser.Scene {
     this.wallContainer.removeAll(true)
     this.entityContainer.removeAll(true)
 
+    // FOV可視/探索済み集合を毎フレーム構築（Array.includes の O(n) を回避）
+    if (this.fovActive) {
+      this.visibleSet = new Set(this.gameStore.visibleTiles as string[])
+      this.exploredSet = new Set(this.gameStore.exploredTiles as string[])
+    }
+
     const playerPos = this.gameStore.player.position
     const halfViewX = Math.floor(this.viewTilesX / 2)
     const halfViewY = Math.floor(this.viewTilesY / 2)
@@ -337,11 +364,14 @@ export class DungeonScene extends Phaser.Scene {
         if (x < 0 || x >= this.mapWidth || y < 0 || y >= this.mapHeight) continue
         const tile = this.map[y][x]
         if (tile === TILE.FLOOR || tile === TILE.STAIRS) {
+          const vis = this.tileVisibility(x, y)
+          if (vis === 'hidden') continue
+          const dim = vis === 'explored'
           const inViewport = x >= this.viewStartX && x < endX && y >= this.viewStartY && y < endY
           if (inViewport && tile === TILE.FLOOR) {
-            this.drawFloorTile(x, y)
+            this.drawFloorTile(x, y, dim)
           }
-          this.drawBorderOverlay(x, y)
+          this.drawBorderOverlay(x, y, dim)
         }
       }
     }
@@ -351,14 +381,18 @@ export class DungeonScene extends Phaser.Scene {
       for (let x = this.viewStartX; x < endX; x++) {
         if (x < 0 || x >= this.mapWidth || y < 0 || y >= this.mapHeight) continue
         if (this.map[y][x] === TILE.STAIRS) {
+          const vis = this.tileVisibility(x, y)
+          if (vis === 'hidden') continue
+          const dim = vis === 'explored'
           const sx = this.offsetX + (x - this.viewStartX) * this.tileWidth + this.tileWidth / 2
           const sy = this.offsetY + (y - this.viewStartY) * this.tileHeight + this.tileHeight / 2
           const stairsTile = this.add.image(sx, sy, 'floor_stairs')
           stairsTile.setScale(this.tileScale)
+          if (dim) stairsTile.setTint(DIM_TINT)
           this.wallContainer.add(stairsTile)
           // 南に壁がある場合、ふち（wall_top_mid）を階段の上に重ねる
           if (!this.isFloor(x, y + 1)) {
-            this.addWallTile('wall_top_mid', x, y)
+            this.addWallTile('wall_top_mid', x, y, dim)
           }
         }
       }
@@ -373,7 +407,16 @@ export class DungeonScene extends Phaser.Scene {
     }
   }
 
-  private drawFloorTile(tileX: number, tileY: number) {
+  // タイルの可視状態を返す（FOV無効時は常に visible = 全描画）
+  private tileVisibility(x: number, y: number): TileVisibility {
+    if (!this.fovActive) return 'visible'
+    const key = `${x},${y}`
+    if (this.visibleSet.has(key)) return 'visible'
+    if (this.exploredSet.has(key)) return 'explored'
+    return 'hidden'
+  }
+
+  private drawFloorTile(tileX: number, tileY: number, dim = false) {
     const screenTileX = tileX - this.viewStartX
     const screenTileY = tileY - this.viewStartY
     const x = this.offsetX + screenTileX * this.tileWidth + this.tileWidth / 2
@@ -382,11 +425,12 @@ export class DungeonScene extends Phaser.Scene {
     const textureKey = `floor_${((tileX * 7 + tileY * 13) % 8) + 1}`
     const tile = this.add.image(x, y, textureKey)
     tile.setScale(this.tileScale)
+    if (dim) tile.setTint(DIM_TINT)
     this.floorContainer.add(tile)
   }
 
   // グリッド座標に壁タイルを配置
-  private addWallTile(texture: string, gridX: number, gridY: number) {
+  private addWallTile(texture: string, gridX: number, gridY: number, dim = false) {
     const screenX = gridX - this.viewStartX
     const screenY = gridY - this.viewStartY
     if (
@@ -401,11 +445,12 @@ export class DungeonScene extends Phaser.Scene {
     const img = this.add.image(x, y, texture)
     img.setOrigin(0, 0)
     img.setScale(this.tileScale)
+    if (dim) img.setTint(DIM_TINT)
     this.wallContainer.add(img)
   }
 
   // 床セルの隣接壁にタイルを配置
-  private drawBorderOverlay(tileX: number, tileY: number) {
+  private drawBorderOverlay(tileX: number, tileY: number, dim = false) {
     const hasN = this.isFloor(tileX, tileY - 1)
     const hasE = this.isFloor(tileX + 1, tileY)
     const hasS = this.isFloor(tileX, tileY + 1)
@@ -414,41 +459,41 @@ export class DungeonScene extends Phaser.Scene {
     // === 直線部分 ===
     // 北に壁: 前面 + キャップ
     if (!hasN) {
-      this.addWallTile('wall_mid', tileX, tileY - 1)
-      this.addWallTile('wall_top_mid', tileX, tileY - 2)
+      this.addWallTile('wall_mid', tileX, tileY - 1, dim)
+      this.addWallTile('wall_top_mid', tileX, tileY - 2, dim)
     }
     // 南に壁: 前面 + キャップ（キャップは床セル自体に重ねる、ただし階段は隠さない）
     if (!hasS) {
-      this.addWallTile('wall_mid', tileX, tileY + 1)
+      this.addWallTile('wall_mid', tileX, tileY + 1, dim)
       if (this.map[tileY]?.[tileX] !== TILE.STAIRS) {
-        this.addWallTile('wall_top_mid', tileX, tileY)
+        this.addWallTile('wall_top_mid', tileX, tileY, dim)
       }
     }
     // 西に壁
     if (!hasW) {
-      this.addWallTile('wall_outer_mid_left', tileX - 1, tileY)
+      this.addWallTile('wall_outer_mid_left', tileX - 1, tileY, dim)
     }
     // 東に壁
     if (!hasE) {
-      this.addWallTile('wall_outer_mid_right', tileX + 1, tileY)
+      this.addWallTile('wall_outer_mid_right', tileX + 1, tileY, dim)
     }
 
     // === 外側角（凸角）===
     if (!hasN && !hasW) {
-      this.addWallTile('wall_outer_top_left', tileX - 1, tileY - 2)
-      this.addWallTile('wall_top_left', tileX, tileY - 2)
-      this.addWallTile('wall_outer_mid_left', tileX - 1, tileY - 1)
+      this.addWallTile('wall_outer_top_left', tileX - 1, tileY - 2, dim)
+      this.addWallTile('wall_top_left', tileX, tileY - 2, dim)
+      this.addWallTile('wall_outer_mid_left', tileX - 1, tileY - 1, dim)
     }
     if (!hasN && !hasE) {
-      this.addWallTile('wall_outer_top_right', tileX + 1, tileY - 2)
-      this.addWallTile('wall_top_right', tileX, tileY - 2)
-      this.addWallTile('wall_outer_mid_right', tileX + 1, tileY - 1)
+      this.addWallTile('wall_outer_top_right', tileX + 1, tileY - 2, dim)
+      this.addWallTile('wall_top_right', tileX, tileY - 2, dim)
+      this.addWallTile('wall_outer_mid_right', tileX + 1, tileY - 1, dim)
     }
     if (!hasS && !hasW) {
-      this.addWallTile('wall_outer_front_left', tileX - 1, tileY + 1)
+      this.addWallTile('wall_outer_front_left', tileX - 1, tileY + 1, dim)
     }
     if (!hasS && !hasE) {
-      this.addWallTile('wall_outer_front_right', tileX + 1, tileY + 1)
+      this.addWallTile('wall_outer_front_right', tileX + 1, tileY + 1, dim)
     }
 
     // TODO: 内側角（凹角）は別途マップが大きくなってから対応
@@ -496,6 +541,8 @@ export class DungeonScene extends Phaser.Scene {
   private drawItems(viewStartX: number, viewStartY: number, endX: number, endY: number) {
     for (const item of this.gameStore.floorItems) {
       if (item.x < viewStartX || item.x >= endX || item.y < viewStartY || item.y >= endY) continue
+      // FOV有効時、今見えているマスのアイテムのみ描画
+      if (this.tileVisibility(item.x, item.y) !== 'visible') continue
       const screenTileX = item.x - viewStartX
       const screenTileY = item.y - viewStartY
       const x = this.offsetX + screenTileX * this.tileWidth + this.tileWidth / 2
@@ -520,6 +567,8 @@ export class DungeonScene extends Phaser.Scene {
     for (const enemy of this.gameStore.enemies) {
       if (enemy.x < viewStartX || enemy.x >= endX || enemy.y < viewStartY || enemy.y >= endY)
         continue
+      // FOV有効時、今見えているマスの敵のみ描画
+      if (this.tileVisibility(enemy.x, enemy.y) !== 'visible') continue
       const screenTileX = enemy.x - viewStartX
       const screenTileY = enemy.y - viewStartY
       const x = this.offsetX + screenTileX * this.tileWidth + this.tileWidth / 2

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -5,6 +5,7 @@ import {
   equipItem as calcEquip,
   unequipItem as calcUnequip,
 } from '~/game/systems/ItemSystem'
+import { computeVisible } from '~/game/systems/FOVSystem'
 import gameConfig from '~/game/data/gameConfig.json'
 
 interface PlayerState {
@@ -69,7 +70,8 @@ interface GameState {
   turn: number
   messageLog: string[]
   currentMap: number[][]
-  exploredTiles: string[] // "x,y" 形式の探索済み座標
+  exploredTiles: string[] // "x,y" 形式の探索済み座標（過去に一度でも見えた）
+  visibleTiles: string[] // "x,y" 形式の現在可視の座標（今見えている）
   gameResult: GameResult
   defeatedEnemies: number
   maxFloorReached: number
@@ -103,6 +105,7 @@ export const useGameStore = defineStore('game', {
     messageLog: [],
     currentMap: [],
     exploredTiles: [],
+    visibleTiles: [],
     gameResult: 'active',
     defeatedEnemies: 0,
     maxFloorReached: 1,
@@ -245,17 +248,14 @@ export const useGameStore = defineStore('game', {
 
       // ゴールドはプレイヤーの所持金に加算
       if (def.type === 'gold') {
-        const goldAmount =
-          amount > 1 ? amount : gameConfig.goldConfig?.defaultDropAmount ?? 10
+        const goldAmount = amount > 1 ? amount : (gameConfig.goldConfig?.defaultDropAmount ?? 10)
         this.player.gold += goldAmount
         return { message: `${goldAmount}Gを拾った！`, toGold: true }
       }
 
       // スタック可能アイテムは既存スタックに合算
       if (def.stackable) {
-        const existing = this.inventory.find(
-          (i) => i.itemId === itemId && !i.equipped
-        )
+        const existing = this.inventory.find((i) => i.itemId === itemId && !i.equipped)
         if (existing) {
           existing.stack = (existing.stack ?? 1) + amount
           return { message: `${def.name}を拾った！`, toGold: false }
@@ -345,28 +345,39 @@ export const useGameStore = defineStore('game', {
       this.currentMap = map.map((row) => [...row])
     },
 
-    revealAround(cx: number, cy: number, radius: number = 3) {
-      const mapH = this.currentMap.length
-      const mapW = mapH > 0 ? this.currentMap[0].length : 0
-      for (let dy = -radius; dy <= radius; dy++) {
-        for (let dx = -radius; dx <= radius; dx++) {
-          const x = cx + dx
-          const y = cy + dy
-          if (x < 0 || x >= mapW || y < 0 || y >= mapH) continue
-          const key = `${x},${y}`
-          if (!this.exploredTiles.includes(key)) {
-            this.exploredTiles.push(key)
-          }
-        }
+    /**
+     * FOV（視界）を再計算する。
+     * 現在可視のタイル集合 (visibleTiles) を計算し直し、探索済み (exploredTiles) に和集合で追加する。
+     * @param cx 視点 X（省略時はプレイヤー位置）
+     * @param cy 視点 Y（省略時はプレイヤー位置）
+     * @param range 視界半径（省略時は gameConfig の viewRange）
+     */
+    recomputeFov(cx?: number, cy?: number, range?: number) {
+      const px = cx ?? this.player.position.x
+      const py = cy ?? this.player.position.y
+      const r = range ?? gameConfig.playerConfig?.viewRange ?? 6
+
+      const visible = computeVisible(this.currentMap, px, py, r)
+      this.visibleTiles = [...visible]
+
+      const explored = new Set(this.exploredTiles)
+      for (const key of visible) {
+        explored.add(key)
       }
+      this.exploredTiles = [...explored]
     },
 
     clearExplored() {
       this.exploredTiles = []
+      this.visibleTiles = []
     },
 
     isExplored(x: number, y: number): boolean {
       return this.exploredTiles.includes(`${x},${y}`)
+    },
+
+    isVisible(x: number, y: number): boolean {
+      return this.visibleTiles.includes(`${x},${y}`)
     },
 
     decreaseSatiation(amount: number) {

--- a/tests/unit/systems/FOVSystem.test.ts
+++ b/tests/unit/systems/FOVSystem.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { computeVisible } from '../../../game/systems/FOVSystem'
+
+// 0=床, 1=壁, 2=階段
+describe('FOVSystem.computeVisible', () => {
+  it('視点マスは常に可視', () => {
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ]
+    const v = computeVisible(map, 1, 1, 5)
+    expect(v.has('1,1')).toBe(true)
+  })
+
+  it('開けた部屋では範囲内の床がすべて可視', () => {
+    const map = Array.from({ length: 5 }, () => Array(5).fill(0))
+    const v = computeVisible(map, 2, 2, 5)
+    // 中心・辺・四隅すべて見える
+    expect(v.has('2,2')).toBe(true)
+    expect(v.has('0,0')).toBe(true)
+    expect(v.has('4,4')).toBe(true)
+    expect(v.has('0,4')).toBe(true)
+    expect(v.has('4,0')).toBe(true)
+    expect(v.size).toBe(25)
+  })
+
+  it('壁で視界が遮られる（壁自体は見えるが、その先は見えない）', () => {
+    const map = [
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [1, 1, 1, 1, 1], // 壁の行
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+    ]
+    const v = computeVisible(map, 2, 1, 5)
+    expect(v.has('2,1')).toBe(true) // 視点
+    expect(v.has('2,0')).toBe(true) // 視点の上（床）
+    expect(v.has('2,2')).toBe(true) // 目の前の壁は見える
+    expect(v.has('2,3')).toBe(false) // 壁の向こうは見えない
+    expect(v.has('2,4')).toBe(false)
+  })
+
+  it('視界範囲外は不可視（Chebyshev距離 > range）', () => {
+    const big = Array.from({ length: 11 }, () => Array(11).fill(0))
+    const v = computeVisible(big, 5, 5, 2)
+    expect(v.has('5,5')).toBe(true) // 距離0
+    expect(v.has('7,5')).toBe(true) // 距離2（範囲内）
+    expect(v.has('5,3')).toBe(true) // 距離2（範囲内）
+    expect(v.has('8,5')).toBe(false) // 距離3（範囲外）
+    expect(v.has('5,2')).toBe(false) // 距離3（範囲外）
+  })
+
+  it('可視集合に範囲外座標は含まれない', () => {
+    const map = [
+      [0, 0],
+      [0, 0],
+    ]
+    const v = computeVisible(map, 0, 0, 5)
+    for (const key of v) {
+      const [x, y] = key.split(',').map(Number)
+      expect(x).toBeGreaterThanOrEqual(0)
+      expect(x).toBeLessThan(2)
+      expect(y).toBeGreaterThanOrEqual(0)
+      expect(y).toBeLessThan(2)
+    }
+  })
+
+  it('階段(2)は光を通し可視になる', () => {
+    const map = [
+      [0, 0, 0],
+      [0, 0, 2],
+      [0, 0, 0],
+    ]
+    const v = computeVisible(map, 0, 1, 5)
+    expect(v.has('2,1')).toBe(true)
+  })
+
+  it('空マップは空集合を返す', () => {
+    expect(computeVisible([], 0, 0, 5).size).toBe(0)
+  })
+})


### PR DESCRIPTION
## 概要

rot-js のシャドウキャスティングによる視界（FOV / fog of war）を導入する。Closes #12

> [!NOTE]
> このPRは #61（8方向移動）にスタックしています。base は `feat/m5-8way`。#61 マージ後に base を `main` へ切り替えてください。

## 変更内容

- **`game/systems/FOVSystem.ts`（新規・純粋関数）**: `computeVisible(map, x, y, range): Set<string>`。rot-js `FOV.PreciseShadowcasting`（topology 8）で360度視界を計算。`lightPasses` は「範囲内かつ壁でない」。壁自体は可視（壁面描画のため集合に含む）。Phaser非依存・rot-js のみ。
- **`stores/gameStore.ts`**: `visibleTiles: string[]`（現在可視）を追加。`revealAround`（正方形リビール）を **`recomputeFov(cx?, cy?, range?)` に置換** — visible を再計算し explored へ和集合追加。`isVisible(x,y)` getter を追加。`clearExplored` は visible もクリア。
- **`composables/useGameLoop.ts`**: 移動後（`playerMove`）とフロア初期化（`initFloor`）の `revealAround` 呼び出しを `recomputeFov` に変更。
- **`phaser/scenes/DungeonScene.ts`**: 可視性フィルタを実装。
  - `visible` → 通常描画 / `explored`（探索済みだが今は見えない）→ 減光（`setTint(0x555566)`） / 未探索 → 非描画。
  - 床・壁オーバーレイ・階段に減光/非描画を適用。敵・アイテムは **visible のときだけ** 描画。プレイヤーは常時描画。
  - マウント／リロード直後の空表示を避けるため `create()` で `recomputeFov()` を再計算。
- **`game/data/gameConfig.json`**: `playerConfig.fovEnabled: true` を追加。

## デフォルトの視界挙動（設計判断）

デッドコンフィグだった `viewRange`(6) / `debugConfig.showFOV` を実際に配線し、あわせて新フラグ `playerConfig.fovEnabled` を追加した。有効判定は次のとおり:

```
fovActive = playerConfig.fovEnabled || debugConfig.showFOV
```

- **`playerConfig.fovEnabled`（既定 `true`）** — FOV のマスタースイッチ。既定ONなので、通常プレイでは **デフォルトで視界制限（fog of war）が有効**。ローグライクとして自然な既定。
- **`debugConfig.showFOV`（既定 `false`）** — issue要件どおり「true で FOV 有効」の意味を維持（`fovEnabled=false` でも強制的にFOVを有効化できる補助スイッチ）。
- **従来どおりの全描画に戻す**には `fovEnabled=false` かつ `showFOV=false` の両方を設定する。

`showFOV=false` 単独では従来の全描画に戻らない点が元の素朴な要件文とは異なるが、これは issue が許容している「FOVをデフォルト有効にするための playerConfig フラグ追加」の方針に沿った実装。視界半径には `playerConfig.viewRange`(=6) を使用。

## テスト

- `tests/unit/systems/FOVSystem.test.ts`（新規）: 視点は常に可視 / 開けた部屋は範囲内全可視 / 壁で遮蔽（壁は見えるがその先は不可視）/ range外は不可視 / 可視集合に範囲外座標を含まない / 階段(2)は光を通す / 空マップは空集合。
- `npm run test`: 11ファイル 147件 グリーン。`eslint .` エラーなし。`nuxi typecheck` エラーなし。

## 検証手順（手動）

1. `npm run dev` で起動（既定 `fovEnabled=true`）。壁の向こう・視界範囲外のタイル/敵/アイテムが隠れることを確認。
2. 一度見た床から離れると、その床が減光表示（探索済み）になることを確認。
3. `game/data/gameConfig.json` で `fovEnabled=false` にすると従来どおり全描画に戻ることを確認。
4. `showFOV=true` にすると `fovEnabled` に関わらずFOVが有効になることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)