### PR TITLE
feat(m4): 特殊アイテム — 巻物3種・謎の金庫 (#36)

### DIFF
--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -50,6 +50,10 @@
   "deathPenalty": {
     "goldLossRate": 1.0
   },
+  "strangeSafe": {
+    "minGold": 50,
+    "maxGold": 200
+  },
   "dungeonConfig": {
     "floorsTotal": 10,
     "enemiesPerFloor": [3, 4, 5, 6, 7, 8, 9, 10, 12, 15]

--- a/game/data/items.ts
+++ b/game/data/items.ts
@@ -1,4 +1,12 @@
-export type ItemType = 'weapon' | 'armor' | 'potion' | 'food' | 'scroll' | 'gold' | 'special' | 'other'
+export type ItemType =
+  | 'weapon'
+  | 'armor'
+  | 'potion'
+  | 'food'
+  | 'scroll'
+  | 'gold'
+  | 'special'
+  | 'other'
 
 export interface ItemEffect {
   hp?: number
@@ -147,6 +155,44 @@ export const ITEMS: Record<string, ItemDef> = {
     usable: true,
     equippable: false,
     stackable: true,
+  },
+  escape_scroll: {
+    id: 'escape_scroll',
+    name: 'リレミトの巻物',
+    description: 'ダンジョンから脱出して拠点へ戻る',
+    type: 'scroll',
+    effect: { scrollAction: 'escape' },
+    usable: true,
+    equippable: false,
+    stackable: true,
+  },
+  teleport_scroll: {
+    id: 'teleport_scroll',
+    name: 'ワープの巻物',
+    description: 'フロア内のランダムな場所へ瞬間移動する',
+    type: 'scroll',
+    effect: { scrollAction: 'teleport' },
+    usable: true,
+    equippable: false,
+    stackable: true,
+  },
+  map_scroll: {
+    id: 'map_scroll',
+    name: '地図の巻物',
+    description: '現在のフロアの地図をすべて見渡す',
+    type: 'scroll',
+    effect: { scrollAction: 'revealMap' },
+    usable: true,
+    equippable: false,
+    stackable: true,
+  },
+  strange_safe: {
+    id: 'strange_safe',
+    name: '謎の金庫',
+    description: '重くて開かない。拠点に持ち帰れば開けられそうだ',
+    type: 'special',
+    usable: false,
+    equippable: false,
   },
   gold: {
     id: 'gold',

--- a/game/dungeon/Abyss/F2.ts
+++ b/game/dungeon/Abyss/F2.ts
@@ -17,6 +17,8 @@ const floor: FloorConfig = {
       { itemId: 'sword', weight: 1 },
       { itemId: 'shield', weight: 1 },
       { itemId: 'antidote', weight: 1 },
+      { itemId: 'escape_scroll', weight: 1 },
+      { itemId: 'teleport_scroll', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/Abyss/F4.ts
+++ b/game/dungeon/Abyss/F4.ts
@@ -16,6 +16,8 @@ const floor: FloorConfig = {
       { itemId: 'big_bread', weight: 1 },
       { itemId: 'great_sword', weight: 1 },
       { itemId: 'heavy_armor', weight: 1 },
+      { itemId: 'map_scroll', weight: 1 },
+      { itemId: 'strange_safe', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/Abyss/F6.ts
+++ b/game/dungeon/Abyss/F6.ts
@@ -16,6 +16,8 @@ const floor: FloorConfig = {
       { itemId: 'big_bread', weight: 2 },
       { itemId: 'great_sword', weight: 1 },
       { itemId: 'heavy_armor', weight: 1 },
+      { itemId: 'escape_scroll', weight: 1 },
+      { itemId: 'strange_safe', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/DarkCastle/F3.ts
+++ b/game/dungeon/DarkCastle/F3.ts
@@ -14,6 +14,8 @@ const floor: FloorConfig = {
       { itemId: 'sword', weight: 1 },
       { itemId: 'great_sword', weight: 1 },
       { itemId: 'shield', weight: 1 },
+      { itemId: 'escape_scroll', weight: 1 },
+      { itemId: 'map_scroll', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/DarkCastle/F5.ts
+++ b/game/dungeon/DarkCastle/F5.ts
@@ -18,6 +18,8 @@ const floor: FloorConfig = {
       { itemId: 'big_bread', weight: 1 },
       { itemId: 'great_sword', weight: 1 },
       { itemId: 'heavy_armor', weight: 1 },
+      { itemId: 'teleport_scroll', weight: 1 },
+      { itemId: 'strange_safe', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/SilentForest/F2.ts
+++ b/game/dungeon/SilentForest/F2.ts
@@ -13,6 +13,8 @@ const floor: FloorConfig = {
       { itemId: 'bread', weight: 2 },
       { itemId: 'sword', weight: 3 },
       { itemId: 'shield', weight: 1 },
+      { itemId: 'teleport_scroll', weight: 1 },
+      { itemId: 'map_scroll', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/SilentForest/F3.ts
+++ b/game/dungeon/SilentForest/F3.ts
@@ -13,6 +13,8 @@ const floor: FloorConfig = {
       { itemId: 'bread', weight: 2 },
       { itemId: 'sword', weight: 3 },
       { itemId: 'shield', weight: 1 },
+      { itemId: 'escape_scroll', weight: 1 },
+      { itemId: 'strange_safe', weight: 1 },
     ],
   },
 }

--- a/game/dungeon/SilentForest/F4.ts
+++ b/game/dungeon/SilentForest/F4.ts
@@ -14,6 +14,9 @@ const floor: FloorConfig = {
       { itemId: 'sword', weight: 3 },
       { itemId: 'shield', weight: 1 },
       { itemId: 'antidote', weight: 1 },
+      { itemId: 'map_scroll', weight: 1 },
+      { itemId: 'teleport_scroll', weight: 1 },
+      { itemId: 'escape_scroll', weight: 1 },
     ],
   },
 }

--- a/game/systems/EconomySystem.ts
+++ b/game/systems/EconomySystem.ts
@@ -14,3 +14,15 @@ export function computeDeathGoldLoss(
   const kept = gold - lost
   return { lost, kept }
 }
+
+// 謎の金庫を開けたときの獲得ゴールド（min..max の一様乱数, 両端含む）。
+// rng は 0<=x<1 を返す関数（テスト時に注入可能）。
+export function rollSafeGold(
+  minGold: number,
+  maxGold: number,
+  rng: () => number = Math.random
+): number {
+  const min = Math.max(0, Math.floor(minGold))
+  const max = Math.max(min, Math.floor(maxGold))
+  return min + Math.floor(rng() * (max - min + 1))
+}

--- a/game/systems/ItemSystem.ts
+++ b/game/systems/ItemSystem.ts
@@ -13,6 +13,8 @@ export interface UseResult {
   success: boolean
   message: string
   consumed: boolean
+  // 巻物の効果種別。実際の副作用（移動・地図開示・脱出）は呼び出し側（store/scene）が処理する
+  scrollAction?: 'teleport' | 'revealMap' | 'escape'
 }
 
 export function useItem(itemDef: ItemDef, player: PlayerLike): UseResult {
@@ -21,6 +23,17 @@ export function useItem(itemDef: ItemDef, player: PlayerLike): UseResult {
   }
 
   const effect = itemDef.effect ?? {}
+
+  // 巻物: 効果本体は呼び出し側で処理するため、種別だけ返す
+  if (effect.scrollAction) {
+    return {
+      success: true,
+      message: `${itemDef.name}を読んだ`,
+      consumed: true,
+      scrollAction: effect.scrollAction,
+    }
+  }
+
   const messages: string[] = []
 
   if (typeof effect.hp === 'number' && effect.hp > 0) {
@@ -65,10 +78,7 @@ export interface EquipResult {
   defenseDelta: number
 }
 
-export function equipItem(
-  itemDef: ItemDef,
-  currentEquippedId: string | null
-): EquipResult {
+export function equipItem(itemDef: ItemDef, currentEquippedId: string | null): EquipResult {
   if (!itemDef.equippable) {
     return {
       success: false,
@@ -94,9 +104,11 @@ export function equipItem(
   }
 }
 
-export function unequipItem(
-  itemDef: ItemDef
-): { attackDelta: number; defenseDelta: number; message: string } {
+export function unequipItem(itemDef: ItemDef): {
+  attackDelta: number
+  defenseDelta: number
+  message: string
+} {
   const attack = itemDef.effect?.attack ?? 0
   const defense = itemDef.effect?.defense ?? 0
   return {

--- a/pages/village.vue
+++ b/pages/village.vue
@@ -28,9 +28,17 @@
 
   const selectedDungeonId = ref(DEFAULT_DUNGEON_ID)
 
+  // 持ち帰った謎の金庫の開封結果
+  const safeResult = ref<{ count: number; gold: number } | null>(null)
+
   onMounted(() => {
     // localStorage から永続データを同期
     gameStore.loadMeta()
+    // 持ち帰った謎の金庫を開封してゴールドを獲得
+    const opened = gameStore.openStrangeSafes()
+    if (opened.count > 0) {
+      safeResult.value = opened
+    }
   })
 
   const departDungeon = () => {
@@ -63,6 +71,9 @@
         前回: {{ lastRunLabel }} / B{{ lastRun.floor }}F
         <template v-if="lastRun.goldBanked > 0"> ・ +{{ lastRun.goldBanked }}G</template>
         <template v-if="lastRun.goldLost > 0"> ・ -{{ lastRun.goldLost }}G</template>
+      </p>
+      <p v-if="safeResult" class="safe-result">
+        謎の金庫を開けた！ +{{ safeResult.gold }}G（{{ safeResult.count }}個）
       </p>
     </div>
 
@@ -158,6 +169,12 @@
 
   .lastrun.is-dead {
     color: #ff8a8a;
+  }
+
+  .safe-result {
+    margin: 0.4rem 0 0;
+    font-size: 0.6rem;
+    color: #ffd700;
   }
 
   .shop-title,

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -9,6 +9,8 @@ const ITEM_TINT: Record<string, number> = {
   armor: 0x66aaff,
   potion: 0x66ff66,
   food: 0xffcc66,
+  scroll: 0xcc99ff,
+  special: 0xffaa33,
   gold: 0xffd700,
   other: 0xcccccc,
 }
@@ -755,14 +757,30 @@ export class DungeonScene extends Phaser.Scene {
       if (def.usable) {
         ui.showConfirm(`${def.name} を使用しますか？`, () => {
           const useResult = this.gameStore.useInventoryItem(index)
-          if (useResult.success) {
-            this.updateUI([useResult.message])
-            ui.refreshInventory(this.gameStore.inventory)
-            if (useResult.message.includes('HP') || useResult.message.includes('満腹')) {
-              this.playSE('se_item_use')
-            }
-            this.consumeTurnAfterItem()
+          if (!useResult.success) return
+          this.updateUI([useResult.message])
+          ui.refreshInventory(this.gameStore.inventory)
+
+          const scrollAction = useResult.scrollAction
+          // リレミトの巻物: 脱出（ターン消費なし・拠点へ遷移）
+          if (scrollAction === 'escape') {
+            ui.hideInventory()
+            this.playSE('se_stairs')
+            this.gameLoop.escapeDungeon()
+            return
           }
+          // ワープ/地図の巻物: 効果は store 適用済み、再描画してターン消費
+          if (scrollAction === 'teleport' || scrollAction === 'revealMap') {
+            this.playSE('se_item_use')
+            ui.hideInventory()
+            this.consumeTurnAfterItem()
+            return
+          }
+          // 通常の消費アイテム（ポーション・食料）
+          if (useResult.message.includes('HP') || useResult.message.includes('満腹')) {
+            this.playSE('se_item_use')
+          }
+          this.consumeTurnAfterItem()
         })
         return
       }
@@ -776,6 +794,12 @@ export class DungeonScene extends Phaser.Scene {
             ui.refreshInventory(this.gameStore.inventory)
           }
         })
+        return
+      }
+
+      // 特殊アイテム（謎の金庫など）: 使用/装備どちらでもない
+      if (def.type === 'special') {
+        this.updateUI(['重い金庫だ。拠点に持ち帰れば開けられそうだ。'])
         return
       }
       return

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -5,7 +5,8 @@ import {
   equipItem as calcEquip,
   unequipItem as calcUnequip,
 } from '~/game/systems/ItemSystem'
-import { computeDeathGoldLoss } from '~/game/systems/EconomySystem'
+import { computeDeathGoldLoss, rollSafeGold } from '~/game/systems/EconomySystem'
+import { TILE } from '~/game/data/maps'
 import gameConfig from '~/game/data/gameConfig.json'
 
 interface PlayerState {
@@ -351,7 +352,11 @@ export const useGameStore = defineStore('game', {
       this.floorItems = []
     },
 
-    useInventoryItem(index: number): { success: boolean; message: string } {
+    useInventoryItem(index: number): {
+      success: boolean
+      message: string
+      scrollAction?: 'teleport' | 'revealMap' | 'escape'
+    } {
       const entry = this.inventory[index]
       if (!entry) return { success: false, message: '' }
       const def = ITEMS[entry.itemId]
@@ -365,7 +370,70 @@ export const useGameStore = defineStore('game', {
           this.inventory.splice(index, 1)
         }
       }
-      return { success: result.success, message: result.message }
+      // 巻物の状態変更系はストアで適用（'escape' は経路集約のため呼び出し側で処理）
+      if (result.scrollAction === 'teleport') {
+        this.teleportPlayerRandom()
+      } else if (result.scrollAction === 'revealMap') {
+        this.revealEntireMap()
+      }
+      return {
+        success: result.success,
+        message: result.message,
+        scrollAction: result.scrollAction,
+      }
+    },
+
+    // フロア内のランダムな床マスへプレイヤーを瞬間移動させる
+    teleportPlayerRandom(): boolean {
+      const map = this.currentMap
+      if (!map.length) return false
+      const candidates: { x: number; y: number }[] = []
+      for (let y = 0; y < map.length; y++) {
+        for (let x = 0; x < map[y].length; x++) {
+          if (map[y][x] !== TILE.FLOOR) continue
+          if (x === this.player.position.x && y === this.player.position.y) continue
+          if (this.enemies.some((e) => e.x === x && e.y === y)) continue
+          candidates.push({ x, y })
+        }
+      }
+      if (candidates.length === 0) return false
+      const pick = candidates[Math.floor(Math.random() * candidates.length)]
+      this.setPlayerPosition(pick.x, pick.y)
+      this.revealAround(pick.x, pick.y)
+      return true
+    },
+
+    // 現フロアの全タイルを探索済みにする（地図の巻物）
+    revealEntireMap() {
+      const map = this.currentMap
+      const explored = new Set(this.exploredTiles)
+      for (let y = 0; y < map.length; y++) {
+        for (let x = 0; x < map[y].length; x++) {
+          explored.add(`${x},${y}`)
+        }
+      }
+      this.exploredTiles = Array.from(explored)
+    },
+
+    // 拠点で所持している謎の金庫をすべて開封し、獲得ゴールドを拠点goldへ加算
+    openStrangeSafes(): { count: number; gold: number } {
+      const cfg = gameConfig.strangeSafe ?? { minGold: 50, maxGold: 200 }
+      let count = 0
+      let gold = 0
+      this.inventory = this.inventory.filter((entry) => {
+        if (ITEMS[entry.itemId]?.type !== 'special') return true
+        const times = entry.stack ?? 1
+        for (let i = 0; i < times; i++) {
+          gold += rollSafeGold(cfg.minGold, cfg.maxGold)
+          count++
+        }
+        return false
+      })
+      if (count > 0) {
+        this.meta.gold += gold
+        this.persistMeta()
+      }
+      return { count, gold }
     },
 
     equipInventoryItem(index: number): { success: boolean; message: string } {

--- a/tests/unit/systems/EconomySystem.test.ts
+++ b/tests/unit/systems/EconomySystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeDeathGoldLoss } from '../../../game/systems/EconomySystem'
+import { computeDeathGoldLoss, rollSafeGold } from '../../../game/systems/EconomySystem'
 
 describe('EconomySystem.computeDeathGoldLoss', () => {
   it('lossRate=1 で全ロスト', () => {
@@ -38,5 +38,32 @@ describe('EconomySystem.computeDeathGoldLoss', () => {
   it('lossRateが範囲外でも 0..1 にクランプ', () => {
     expect(computeDeathGoldLoss(100, 2).lost).toBe(100)
     expect(computeDeathGoldLoss(100, -1).lost).toBe(0)
+  })
+})
+
+describe('EconomySystem.rollSafeGold', () => {
+  it('rng=0 で最小値', () => {
+    expect(rollSafeGold(50, 200, () => 0)).toBe(50)
+  })
+
+  it('rng→1 で最大値（両端含む）', () => {
+    expect(rollSafeGold(50, 200, () => 0.999999)).toBe(200)
+  })
+
+  it('rng=0.5 で中央付近', () => {
+    // 50 + floor(0.5 * 151) = 50 + 75 = 125
+    expect(rollSafeGold(50, 200, () => 0.5)).toBe(125)
+  })
+
+  it('常に min..max の範囲内', () => {
+    for (const r of [0, 0.1, 0.33, 0.5, 0.77, 0.99]) {
+      const g = rollSafeGold(50, 200, () => r)
+      expect(g).toBeGreaterThanOrEqual(50)
+      expect(g).toBeLessThanOrEqual(200)
+    }
+  })
+
+  it('min>max でも min にクランプされる', () => {
+    expect(rollSafeGold(200, 50, () => 0.5)).toBe(200)
   })
 })

--- a/tests/unit/systems/ItemSystem.test.ts
+++ b/tests/unit/systems/ItemSystem.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect } from 'vitest'
 import { useItem, equipItem, unequipItem } from '../../../game/systems/ItemSystem'
-import {
-  ITEMS,
-  computeEquipmentStats,
-  makeEquipmentData,
-} from '../../../game/data/items'
+import { ITEMS, computeEquipmentStats, makeEquipmentData } from '../../../game/data/items'
 
-function makePlayer(overrides: Partial<{ hp: number; maxHp: number; satiation: number; maxSatiation: number; attack: number; defense: number }> = {}) {
+function makePlayer(
+  overrides: Partial<{
+    hp: number
+    maxHp: number
+    satiation: number
+    maxSatiation: number
+    attack: number
+    defense: number
+  }> = {}
+) {
   return {
     hp: 50,
     maxHp: 100,
@@ -59,6 +64,32 @@ describe('ItemSystem.useItem', () => {
     const result = useItem(ITEMS.antidote, player)
     expect(result.success).toBe(true)
     expect(result.consumed).toBe(true)
+  })
+
+  it('リレミトの巻物は scrollAction=escape を返す', () => {
+    const player = makePlayer()
+    const result = useItem(ITEMS.escape_scroll, player)
+    expect(result.success).toBe(true)
+    expect(result.consumed).toBe(true)
+    expect(result.scrollAction).toBe('escape')
+  })
+
+  it('ワープの巻物は scrollAction=teleport を返す', () => {
+    const result = useItem(ITEMS.teleport_scroll, makePlayer())
+    expect(result.scrollAction).toBe('teleport')
+    expect(result.consumed).toBe(true)
+  })
+
+  it('地図の巻物は scrollAction=revealMap を返す', () => {
+    const result = useItem(ITEMS.map_scroll, makePlayer())
+    expect(result.scrollAction).toBe('revealMap')
+  })
+
+  it('謎の金庫は使用できない（special）', () => {
+    const result = useItem(ITEMS.strange_safe, makePlayer())
+    expect(result.success).toBe(false)
+    expect(result.consumed).toBe(false)
+    expect(result.scrollAction).toBeUndefined()
   })
 })
 
@@ -131,10 +162,11 @@ describe('ITEMS データ整合性', () => {
     }
   })
 
-  it('gold タイプのアイテムが存在する', () => {
-    // scroll / special は M3 範囲外なので具体的アイテムは未定義 (型は items.ts に予約済み)
+  it('gold / scroll / special タイプのアイテムが存在する', () => {
     const types = Object.values(ITEMS).map((i) => i.type)
     expect(types).toContain('gold')
+    expect(types).toContain('scroll')
+    expect(types).toContain('special')
   })
 
   it('ポーション・食料・スクロール・ゴールドは stackable=true', () => {


### PR DESCRIPTION
## 概要

**#36 特殊アイテム（謎の金庫・リレミトの巻物ほか）** を実装。#37 PR (#63) の上にスタック。

> base: `feat/m4-death-escape` (#63)

## 変更内容

### アイテム定義（`game/data/items.ts`）
| id | 名前 | 効果 |
|---|---|---|
| `escape_scroll` | リレミトの巻物 | `scrollAction:'escape'` ダンジョン脱出 |
| `teleport_scroll` | ワープの巻物 | `scrollAction:'teleport'` フロア内ランダム床へ瞬間移動 |
| `map_scroll` | 地図の巻物 | `scrollAction:'revealMap'` 現フロアの explored 全開 |
| `strange_safe` | 謎の金庫 | `type:'special'` 拠点に持ち帰ると開封（gold入手） |

### ロジック
- `ItemSystem.useItem`: `scrollAction` 分岐を追加。純粋関数のまま「効果種別」を返し、実際の副作用（移動・地図開示・脱出）は store/scene が処理。
- `gameStore`:
  - `useInventoryItem` が `scrollAction` を返却。`teleport`→`teleportPlayerRandom()`、`revealMap`→`revealEntireMap()` を適用（`escape` は経路集約のため scene 側で `escapeDungeon()`）。
  - `teleportPlayerRandom()` 床マス（enemy/現在地除く）へ移動、`revealEntireMap()` 全タイル explored 化。
  - `openStrangeSafes()` 拠点で所持金庫を全開封しランダム gold を拠点goldへ加算。
- `EconomySystem.rollSafeGold(min,max,rng)` 金庫の獲得gold（rng注入可・テスト付き）。`gameConfig.strangeSafe.min/maxGold`（既定 50〜200）。

### UI
- `DungeonScene.handleInventoryAction`: 巻物は usable フローで処理。escape=脱出（ターン消費なし）、teleport/revealMap=再描画+ターン消費、special(金庫)=専用メッセージ（無反応にしない）。
- `village.vue`: 帰還時に金庫を自動開封して「謎の金庫を開けた！ +XG」を表示。
- `ITEM_TINT` に scroll/special を追加（フロア描画の色分け）。

### フロア配置
- SilentForest / DarkCastle / Abyss の複数の非ボスフロアに新アイテムを `weight:1` で出現追加。

## 設計判断

- **謎の金庫**: ダンジョン内では開けられず（メッセージのみ）、**脱出/踏破で拠点に持ち帰ると自動開封**しランダムgoldを獲得。死亡すると持ち物ロストで金庫も失う（=リスクリターン）。開封は拠点到着時に1回だけ（inventoryから除去し二重開封を防止）。
- **teleport**: 既存の床判定（`TILE.FLOOR`）を流用し、enemy占有マス・現在地を除外したランダム床へ移動。

## 検証

- `npx eslint .` パス（0 errors、village.vue の void self-closing warning 1件のみ・非ブロッキング）
- `npm run test` パス（**144 tests**、ItemSystem/EconomySystem に scroll・rollSafeGold のテスト追加）

> 注（Track A との競合可能性）: `teleportPlayerRandom` は `gameStore` の player 位置・`currentMap` を触るため、Track A の8方向移動/FOV と同じ領域。マージ時に解消される前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)