### PR TITLE
feat(m4): 装備システム — 装備強化・鍛冶 (#35)

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -387,6 +387,8 @@ export function useGameLoop() {
     store.resetGame()
     store.setDungeon(dungeonId, dungeon.floors.length)
     initFloor(1)
+    // 拠点に持ち帰った所持品（強化済み装備など）を引き継いで開始
+    store.loadBelongingsIntoInventory()
   }
 
   // ダンジオンから脱出して拠点へ戻る。現ランのゴールドは拠点に持ち帰る。
@@ -399,6 +401,7 @@ export function useGameLoop() {
       floor: store.dungeon.floor,
     })
     store.bankRunGold()
+    store.saveBelongings() // 所持品を拠点へ持ち帰る
     // gameResult の変化を GameCanvas が監視して /village へ遷移する
     store.setGameResult('escaped')
   }

--- a/game/systems/EconomySystem.ts
+++ b/game/systems/EconomySystem.ts
@@ -26,3 +26,10 @@ export function rollSafeGold(
   const max = Math.max(min, Math.floor(maxGold))
   return min + Math.floor(rng() * (max - min + 1))
 }
+
+// 装備強化コスト: base * (multiplier ^ 現在の強化レベル)。
+// currentLevel は「これから +1 する前の」レベル。
+export function computeEnhanceCost(currentLevel: number, base: number, multiplier: number): number {
+  const lvl = Math.max(0, Math.floor(currentLevel))
+  return Math.floor(base * Math.pow(multiplier, lvl))
+}

--- a/pages/village.vue
+++ b/pages/village.vue
@@ -2,13 +2,50 @@
   import { computed, onMounted, ref } from 'vue'
   import { useGameStore } from '~/stores/gameStore'
   import { DUNGEONS, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
+  import { ITEMS } from '~/game/data/items'
+  import { computeEnhanceCost } from '~/game/systems/EconomySystem'
+  import gameConfig from '~/game/data/gameConfig.json'
 
-  // 拠点画面（村）: 脱出・帰還の行き先、永続ゴールドの表示、ダンジョンへの出発
+  // 拠点画面（村）: 脱出・帰還の行き先、永続ゴールドの表示、鍛冶、ダンジョンへの出発
   const router = useRouter()
   const gameStore = useGameStore()
 
+  const equipCfg = gameConfig.equipmentConfig
+
   const gold = computed(() => gameStore.meta.gold)
   const lastRun = computed(() => gameStore.meta.lastRun)
+
+  // 鍛冶: 拠点倉庫の装備一覧（強化対象）。index は meta.storage 上の位置。
+  const equipmentList = computed(() =>
+    gameStore.meta.storage
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => ITEMS[entry.itemId]?.equippable)
+      .map(({ entry, index }) => {
+        const def = ITEMS[entry.itemId]
+        const level = entry.equipmentData?.enhanceLevel ?? 0
+        const maxed = level >= equipCfg.maxEnhanceLevel
+        const cost = computeEnhanceCost(
+          level,
+          equipCfg.enhanceCostBase,
+          equipCfg.enhanceCostMultiplier
+        )
+        return {
+          index,
+          name: def?.name ?? entry.itemId,
+          level,
+          maxed,
+          cost,
+          canAfford: gameStore.meta.gold >= cost,
+        }
+      })
+  )
+
+  const blacksmithMsg = ref('')
+
+  const enhance = (index: number) => {
+    const result = gameStore.enhanceEquipment(index)
+    blacksmithMsg.value = result.message
+  }
 
   const lastRunLabel = computed(() => {
     const r = lastRun.value
@@ -77,10 +114,31 @@
       </p>
     </div>
 
-    <!-- 鍛冶（PR4で中身を実装するプレースホルダ） -->
+    <!-- 鍛冶屋: 持ち帰った装備を gold で強化 -->
     <div class="shop-panel nes-container is-dark is-rounded">
       <p class="shop-title">鍛冶屋</p>
-      <p class="shop-note nes-text is-disabled">まだ準備中だ…（近日開放）</p>
+      <p v-if="equipmentList.length === 0" class="shop-note nes-text is-disabled">
+        強化できる装備がない
+      </p>
+      <ul v-else class="equip-list">
+        <li v-for="eq in equipmentList" :key="eq.index" class="equip-row">
+          <span class="equip-name">
+            {{ eq.name }}
+            <span v-if="eq.level > 0" class="equip-level">+{{ eq.level }}</span>
+          </span>
+          <button
+            v-if="!eq.maxed"
+            class="nes-btn is-small enhance-btn"
+            :class="{ 'is-disabled': !eq.canAfford }"
+            :disabled="!eq.canAfford"
+            @click="enhance(eq.index)"
+          >
+            強化 {{ eq.cost }}G
+          </button>
+          <span v-else class="equip-maxed nes-text is-disabled">MAX</span>
+        </li>
+      </ul>
+      <p v-if="blacksmithMsg" class="shop-msg">{{ blacksmithMsg }}</p>
     </div>
 
     <!-- ダンジョンへ出発 -->
@@ -186,6 +244,46 @@
   .shop-note {
     font-size: 0.6rem;
     margin: 0;
+  }
+
+  .equip-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .equip-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.65rem;
+  }
+
+  .equip-name {
+    flex: 1;
+  }
+
+  .equip-level {
+    color: #ffd700;
+  }
+
+  .enhance-btn {
+    font-size: 0.55rem !important;
+    padding: 0.3rem 0.5rem !important;
+  }
+
+  .equip-maxed {
+    font-size: 0.6rem;
+  }
+
+  .shop-msg {
+    margin: 0.6rem 0 0;
+    font-size: 0.6rem;
+    color: #7fdfa0;
   }
 
   .dungeon-list {

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -15,6 +15,15 @@ const ITEM_TINT: Record<string, number> = {
   other: 0xcccccc,
 }
 
+// インベントリ描画に渡すエントリ（強化レベル・スタック含む）
+type InventoryUIEntry = {
+  itemId: string
+  name: string
+  equipped?: boolean
+  stack?: number
+  equipmentData?: { enhanceLevel: number }
+}
+
 export class DungeonScene extends Phaser.Scene {
   // 表示するタイル数（ビューポート）
   private viewTilesX = 8
@@ -598,9 +607,9 @@ export class DungeonScene extends Phaser.Scene {
         exploredTiles: string[]
       ) => void
       hideMinimap: () => void
-      showInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
+      showInventory: (inventory: InventoryUIEntry[]) => void
       hideInventory: () => void
-      refreshInventory: (inventory: { itemId: string; name: string; equipped?: boolean }[]) => void
+      refreshInventory: (inventory: InventoryUIEntry[]) => void
       moveInventoryCursor: (dx: number, dy: number) => void
       getInventorySelectedIndex: () => number
     }
@@ -1078,8 +1087,9 @@ export class DungeonScene extends Phaser.Scene {
       ease: 'Power2',
       onComplete: () => {
         this.time.delayedCall(1500, () => {
-          // 踏破は生還扱い: 現ランgoldを拠点へ持ち帰る (issue #37)
+          // 踏破は生還扱い: 現ランgoldと所持品を拠点へ持ち帰る (issue #37)
           const banked = this.gameStore.bankRunGold()
+          this.gameStore.saveBelongings()
           this.gameStore.setLastRun({
             result: 'cleared',
             goldBanked: banked,

--- a/phaser/scenes/UIScene.ts
+++ b/phaser/scenes/UIScene.ts
@@ -7,6 +7,15 @@ import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { MinimapOverlay } from '../ui/MinimapOverlay'
 import { InventoryOverlay } from '../ui/InventoryOverlay'
 
+// インベントリ描画に渡すエントリ（強化レベル・スタック含む）
+type InventoryUIEntry = {
+  itemId: string
+  name: string
+  equipped?: boolean
+  stack?: number
+  equipmentData?: { enhanceLevel: number }
+}
+
 export class UIScene extends Phaser.Scene {
   private statusBar!: StatusBar
   private messageLog!: MessageLog
@@ -124,7 +133,7 @@ export class UIScene extends Phaser.Scene {
 
   // --- インベントリ ---
 
-  showInventory(inventory: { itemId: string; name: string; equipped?: boolean }[]) {
+  showInventory(inventory: InventoryUIEntry[]) {
     this.inventory.show(inventory)
   }
 
@@ -132,7 +141,7 @@ export class UIScene extends Phaser.Scene {
     this.inventory.hide()
   }
 
-  refreshInventory(inventory: { itemId: string; name: string; equipped?: boolean }[]) {
+  refreshInventory(inventory: InventoryUIEntry[]) {
     this.inventory.refresh(inventory)
   }
 

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia'
-import { ITEMS, type EquipmentData } from '~/game/data/items'
+import { ITEMS, makeEquipmentData, type EquipmentData } from '~/game/data/items'
+import { useItem as applyUseItem } from '~/game/systems/ItemSystem'
 import {
-  useItem as applyUseItem,
-  equipItem as calcEquip,
-  unequipItem as calcUnequip,
-} from '~/game/systems/ItemSystem'
-import { computeDeathGoldLoss, rollSafeGold } from '~/game/systems/EconomySystem'
+  computeDeathGoldLoss,
+  rollSafeGold,
+  computeEnhanceCost,
+} from '~/game/systems/EconomySystem'
 import { TILE } from '~/game/data/maps'
 import gameConfig from '~/game/data/gameConfig.json'
 
@@ -74,10 +74,21 @@ interface LastRun {
 interface MetaState {
   gold: number // 拠点に預けた永続ゴールド（鍛冶で使用）
   lastRun: LastRun | null
+  storage: InventoryItem[] // 持ち帰った所持品（装備の強化はここに永続）
 }
 
 // localStorage キー（sessionStorage の現ラン継続とは別レイヤ）
 const META_STORAGE_KEY = 'katabasis_meta'
+
+// 装備エントリの実効ボーナス（強化込み）。未装備データは +0 として算出。
+function equipBonusOf(entry: InventoryItem): { attack: number; defense: number } {
+  const def = ITEMS[entry.itemId]
+  if (!def || !def.equippable) return { attack: 0, defense: 0 }
+  const data =
+    entry.equipmentData ??
+    makeEquipmentData(def, 0, gameConfig.equipmentConfig.enhanceBonusPerLevel)
+  return { attack: data.attackBonus, defense: data.defenseBonus }
+}
 
 interface GameState {
   player: PlayerState
@@ -129,6 +140,7 @@ export const useGameStore = defineStore('game', {
     meta: {
       gold: 0,
       lastRun: null,
+      storage: [],
     },
   }),
 
@@ -225,6 +237,7 @@ export const useGameStore = defineStore('game', {
         this.meta = {
           gold: typeof parsed.gold === 'number' ? parsed.gold : 0,
           lastRun: parsed.lastRun ?? null,
+          storage: Array.isArray(parsed.storage) ? parsed.storage : [],
         }
         return true
       } catch {
@@ -247,12 +260,14 @@ export const useGameStore = defineStore('game', {
       this.persistMeta()
     },
 
-    // 死亡時のペナルティ適用: 現ランgoldの一定割合をロスト、残りは拠点へ持ち帰る
+    // 死亡時のペナルティ適用: 現ランgoldの一定割合をロスト、残りは拠点へ持ち帰る。
+    // 持ち帰り品（storage）も失う = 死亡は全ロスト。
     applyDeathPenalty(): { lost: number; kept: number } {
       const rate = gameConfig.deathPenalty?.goldLossRate ?? 1
       const { lost, kept } = computeDeathGoldLoss(this.player.gold, rate)
       this.meta.gold += kept
       this.player.gold = 0
+      this.meta.storage = []
       this.setLastRun({
         result: 'dead',
         goldBanked: kept,
@@ -260,6 +275,53 @@ export const useGameStore = defineStore('game', {
         floor: this.dungeon.floor,
       })
       return { lost, kept }
+    },
+
+    // --- 持ち帰り品（belongings）: 脱出/踏破で拠点へ、死亡で消失、次ラン開始時に再装填 ---
+
+    // 現在の所持品を拠点倉庫へスナップショット保存（脱出・踏破時）
+    saveBelongings() {
+      this.meta.storage = JSON.parse(JSON.stringify(this.inventory))
+      this.persistMeta()
+    },
+
+    // 拠点倉庫の所持品を現ランのインベントリへ展開し、装備中ボーナスを再適用（ラン開始時）
+    loadBelongingsIntoInventory() {
+      this.inventory = JSON.parse(JSON.stringify(this.meta.storage))
+      for (const entry of this.inventory) {
+        if (!entry.equipped) continue
+        const bonus = equipBonusOf(entry)
+        this.player.attack += bonus.attack
+        this.player.defense += bonus.defense
+      }
+    },
+
+    // 装備の強化（鍛冶）。拠点倉庫の装備を対象に meta.gold を消費して enhanceLevel++。
+    enhanceEquipment(storageIndex: number): { success: boolean; message: string } {
+      const entry = this.meta.storage[storageIndex]
+      if (!entry) return { success: false, message: '' }
+      const def = ITEMS[entry.itemId]
+      if (!def || !def.equippable) {
+        return { success: false, message: 'これは強化できない' }
+      }
+      const cfg = gameConfig.equipmentConfig
+      const data = entry.equipmentData ?? makeEquipmentData(def, 0, cfg.enhanceBonusPerLevel)
+      if (data.enhanceLevel >= cfg.maxEnhanceLevel) {
+        return { success: false, message: `${def.name}はこれ以上強化できない` }
+      }
+      const cost = computeEnhanceCost(
+        data.enhanceLevel,
+        cfg.enhanceCostBase,
+        cfg.enhanceCostMultiplier
+      )
+      if (this.meta.gold < cost) {
+        return { success: false, message: `ゴールドが足りない（必要 ${cost}G）` }
+      }
+      this.meta.gold -= cost
+      const newLevel = data.enhanceLevel + 1
+      entry.equipmentData = makeEquipmentData(def, newLevel, cfg.enhanceBonusPerLevel)
+      this.persistMeta()
+      return { success: true, message: `${def.name}を +${newLevel} に強化した！（-${cost}G）` }
     },
 
     addMessage(message: string) {
@@ -343,6 +405,14 @@ export const useGameStore = defineStore('game', {
       const entry: InventoryItem = { itemId, name: def.name }
       if (def.stackable) {
         entry.stack = amount
+      }
+      // 装備品は強化データ（+0）を付与しておく（強化表示・鍛冶の対象になる）
+      if (def.equippable) {
+        entry.equipmentData = makeEquipmentData(
+          def,
+          0,
+          gameConfig.equipmentConfig.enhanceBonusPerLevel
+        )
       }
       this.inventory.push(entry)
       return { message: `${def.name}を拾った！`, toGold: false }
@@ -441,43 +511,47 @@ export const useGameStore = defineStore('game', {
       if (!entry) return { success: false, message: '' }
       const def = ITEMS[entry.itemId]
       if (!def) return { success: false, message: '' }
-
-      // 既に装備済みなら外す
-      if (entry.equipped) {
-        const unequipped = calcUnequip(def)
-        this.player.attack += unequipped.attackDelta
-        this.player.defense += unequipped.defenseDelta
-        entry.equipped = false
-        return { success: true, message: unequipped.message }
+      if (!def.equippable) {
+        return { success: false, message: `${def.name}は装備できない` }
       }
 
-      // 同タイプの装備中アイテムを検索（1スロット1装備）
+      // 既に装備済みなら外す（強化込みボーナスを差し引く）
+      if (entry.equipped) {
+        const bonus = equipBonusOf(entry)
+        this.player.attack -= bonus.attack
+        this.player.defense -= bonus.defense
+        entry.equipped = false
+        return { success: true, message: `${def.name}を外した` }
+      }
+
+      // 同タイプの装備中アイテムを外す（1スロット1装備）
       const currentIndex = this.inventory.findIndex(
         (i, idx) => idx !== index && i.equipped && ITEMS[i.itemId]?.type === def.type
       )
-      const currentId = currentIndex >= 0 ? this.inventory[currentIndex].itemId : null
-      const result = calcEquip(def, currentId)
-      if (!result.success) {
-        return { success: false, message: result.message }
-      }
       if (currentIndex >= 0) {
-        this.inventory[currentIndex].equipped = false
+        const current = this.inventory[currentIndex]
+        const curBonus = equipBonusOf(current)
+        this.player.attack -= curBonus.attack
+        this.player.defense -= curBonus.defense
+        current.equipped = false
       }
-      this.player.attack += result.attackDelta
-      this.player.defense += result.defenseDelta
+
+      // 新しい装備の強化込みボーナスを加算
+      const bonus = equipBonusOf(entry)
+      this.player.attack += bonus.attack
+      this.player.defense += bonus.defense
       entry.equipped = true
-      return { success: true, message: result.message }
+      return { success: true, message: `${def.name}を装備した` }
     },
 
     dropInventoryItem(index: number): { success: boolean; message: string; itemId: string | null } {
       const entry = this.inventory[index]
       if (!entry) return { success: false, message: '', itemId: null }
-      const def = ITEMS[entry.itemId]
-      // 装備中なら先に外す
-      if (entry.equipped && def) {
-        const u = calcUnequip(def)
-        this.player.attack += u.attackDelta
-        this.player.defense += u.defenseDelta
+      // 装備中なら先に外す（強化込みボーナスを差し引く）
+      if (entry.equipped) {
+        const bonus = equipBonusOf(entry)
+        this.player.attack -= bonus.attack
+        this.player.defense -= bonus.defense
       }
       const name = entry.name
       const itemId = entry.itemId

--- a/tests/unit/systems/EconomySystem.test.ts
+++ b/tests/unit/systems/EconomySystem.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { computeDeathGoldLoss, rollSafeGold } from '../../../game/systems/EconomySystem'
+import {
+  computeDeathGoldLoss,
+  rollSafeGold,
+  computeEnhanceCost,
+} from '../../../game/systems/EconomySystem'
 
 describe('EconomySystem.computeDeathGoldLoss', () => {
   it('lossRate=1 で全ロスト', () => {
@@ -65,5 +69,38 @@ describe('EconomySystem.rollSafeGold', () => {
 
   it('min>max でも min にクランプされる', () => {
     expect(rollSafeGold(200, 50, () => 0.5)).toBe(200)
+  })
+})
+
+describe('EconomySystem.computeEnhanceCost', () => {
+  // gameConfig 既定: base=100, multiplier=1.5
+  it('level0 は base', () => {
+    expect(computeEnhanceCost(0, 100, 1.5)).toBe(100)
+  })
+
+  it('level1 は base*1.5', () => {
+    expect(computeEnhanceCost(1, 100, 1.5)).toBe(150)
+  })
+
+  it('level2 は base*1.5^2（端数切り捨て）', () => {
+    expect(computeEnhanceCost(2, 100, 1.5)).toBe(225)
+  })
+
+  it('level3 は切り捨てで337', () => {
+    // 100 * 3.375 = 337.5 -> 337
+    expect(computeEnhanceCost(3, 100, 1.5)).toBe(337)
+  })
+
+  it('レベルが上がるほど単調増加する', () => {
+    let prev = -1
+    for (let lvl = 0; lvl <= 9; lvl++) {
+      const c = computeEnhanceCost(lvl, 100, 1.5)
+      expect(c).toBeGreaterThan(prev)
+      prev = c
+    }
+  })
+
+  it('負のレベルは0扱い', () => {
+    expect(computeEnhanceCost(-1, 100, 1.5)).toBe(100)
   })
 })


### PR DESCRIPTION
## 概要

**#35 装備システム（装備・強化・成長）** を実装。#36 PR (#65) の上にスタック。

> base: `feat/m4-special-items` (#65)

## 変更内容

### equipmentData 配線
- `pickupItem`: 装備品に `makeEquipmentData(def, 0, enhanceBonusPerLevel)` を付与（+N 表示・鍛冶対象になる）。
- `equipInventoryItem` / `dropInventoryItem`: **強化込みボーナス（`equipmentData.attackBonus/defenseBonus`）基準**に変更。base値直参照を廃止し、module-level `equipBonusOf()` で一元化（装備/解除/売却の増減が強化分まで正しく反映）。

### 鍛冶（強化）
- `gameStore.enhanceEquipment(storageIndex)`: 拠点倉庫の装備を `meta.gold` 消費で `enhanceLevel++` → `equipmentData` 再計算。上限 `maxEnhanceLevel`、gold不足/上限時はメッセージ。
- `EconomySystem.computeEnhanceCost(level, base, mult)` = `floor(base * mult^level)`（純粋関数・テスト付き。`gameConfig.equipmentConfig` 使用）。
- `village.vue` に鍛冶屋UI（装備一覧・現在+N・次コスト表示・gold不足/上限で無効化・強化結果メッセージ）。

### 持ち帰り品の永続化（強化を意味あるものにするための最小 carry-over）
- 脱出/踏破: 現在の所持品を `meta.storage` へスナップショット保存（localStorage 永続）。
- ラン開始(`initDungeon`): `meta.storage` から inventory へ再装填し、装備中ボーナスをプレイヤーへ再適用。
- 死亡: `meta.storage` を消失（= 全ロスト）。

### UI 型
- `UIScene` / `DungeonScene` のインベントリ型に `stack?` / `equipmentData?` を追加（`InventoryOverlay` の +N 表示が型的にも通る）。

## 設計判断

- **鍛冶の対象は `meta.storage`（永続倉庫）**: 鍛冶は「ラン間（拠点）」で行うため、リロードしても消えない永続データを対象にした。強化結果は次ダイブ開始時の再装填で実効ステータスに反映される（装備すると強化込みボーナスが乗る）。
- **持ち帰り品の自動 carry-over は「倉庫UI」ではない**: 預入/引出のような管理UIは作らず、脱出/踏破で自動保存・次ラン自動装填・死亡で消失という自動挙動のみ。これがないと強化がラン跨ぎで無意味になるため、経済ループ成立の最小実装として導入した。

## 検証

- `npx eslint .` パス（0 errors、village.vue の void self-closing warning 1件のみ・非ブロッキング）
- `npx vue-tsc --noEmit` パス（**0 errors**、M4全変更の型検証）
- `npm run test` パス（**150 tests**、computeEnhanceCost のテスト追加）

> 注（Track A との競合可能性）: `equipInventoryItem`/`pickupItem` や player.attack/defense の増減、`UIScene`/`DungeonScene` のインベントリ型は Track A(8方向/FOV) と同じファイル群を触るため、マージ時に解消される前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)