### PR TITLE
refactor(m4): ラン終了会計の集約 + 金庫表示の統合（code-reviewフォローアップ）

### DIFF
--- a/composables/useGameLoop.ts
+++ b/composables/useGameLoop.ts
@@ -403,19 +403,8 @@ export function useGameLoop() {
 
   // ダンジオンから脱出して拠点へ戻る。現ランのゴールドは拠点に持ち帰る。
   function escapeDungeon() {
-    const carried = store.player.gold
-    // 謎の金庫は出口で精算（拠点倉庫を経由させないことで複製を防ぐ）
-    const safes = store.openStrangeSafes()
-    store.setLastRun({
-      result: 'escaped',
-      goldBanked: carried,
-      goldLost: 0,
-      floor: store.dungeon.floor,
-      safeGold: safes.gold,
-      safeCount: safes.count,
-    })
-    store.bankRunGold()
-    store.saveBelongings() // 装備品のみ拠点へ持ち帰る
+    // ラン終了の会計処理（金庫精算・gold銀行・装備持ち帰り・lastRun）は store に集約
+    store.finishSurvivedRun('escaped')
     // gameResult の変化を GameCanvas が監視して /village へ遷移する
     store.setGameResult('escaped')
   }

--- a/pages/village.vue
+++ b/pages/village.vue
@@ -65,15 +65,6 @@
 
   const selectedDungeonId = ref(DEFAULT_DUNGEON_ID)
 
-  // 直近ランの謎の金庫の開封結果（開封はダンジョン出口で精算済み。ここは表示のみ）
-  const safeResult = computed(() => {
-    const r = gameStore.meta.lastRun
-    if (r && (r.safeGold ?? 0) > 0) {
-      return { count: r.safeCount ?? 0, gold: r.safeGold ?? 0 }
-    }
-    return null
-  })
-
   onMounted(() => {
     // localStorage から永続データを同期
     gameStore.loadMeta()
@@ -109,9 +100,7 @@
         前回: {{ lastRunLabel }} / B{{ lastRun.floor }}F
         <template v-if="lastRun.goldBanked > 0"> ・ +{{ lastRun.goldBanked }}G</template>
         <template v-if="lastRun.goldLost > 0"> ・ -{{ lastRun.goldLost }}G</template>
-      </p>
-      <p v-if="safeResult" class="safe-result">
-        謎の金庫を開けた！ +{{ safeResult.gold }}G（{{ safeResult.count }}個）
+        <template v-if="(lastRun.safeGold ?? 0) > 0"> ・ 金庫 +{{ lastRun.safeGold }}G</template>
       </p>
     </div>
 
@@ -228,12 +217,6 @@
 
   .lastrun.is-dead {
     color: #ff8a8a;
-  }
-
-  .safe-result {
-    margin: 0.4rem 0 0;
-    font-size: 0.6rem;
-    color: #ffd700;
   }
 
   .shop-title,

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -1179,18 +1179,8 @@ export class DungeonScene extends Phaser.Scene {
       ease: 'Power2',
       onComplete: () => {
         this.time.delayedCall(1500, () => {
-          // 踏破は生還扱い: 現ランgoldと装備品を拠点へ持ち帰り、謎の金庫は出口で精算 (issue #37)
-          const banked = this.gameStore.bankRunGold()
-          const safes = this.gameStore.openStrangeSafes()
-          this.gameStore.saveBelongings()
-          this.gameStore.setLastRun({
-            result: 'cleared',
-            goldBanked: banked,
-            goldLost: 0,
-            floor: this.gameStore.dungeon.floor,
-            safeGold: safes.gold,
-            safeCount: safes.count,
-          })
+          // 踏破は生還扱い: ラン終了の会計処理を store に集約 (issue #37)
+          this.gameStore.finishSurvivedRun('cleared')
           this.gameStore.setGameResult('cleared')
           overlay.destroy()
         })

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -294,6 +294,23 @@ export const useGameStore = defineStore('game', {
       this.persistMeta()
     },
 
+    // 生還（脱出・踏破）時のラン終了会計を集約: 金庫精算 → ランgold銀行 → 装備持ち帰り → lastRun。
+    // 脱出・踏破の両出口で同一処理を使い、ドリフトを防ぐ。死亡は損失ロジックが別物のため applyDeathPenalty 側。
+    finishSurvivedRun(result: 'escaped' | 'cleared') {
+      const carried = this.player.gold
+      const safes = this.openStrangeSafes()
+      this.bankRunGold()
+      this.saveBelongings()
+      this.setLastRun({
+        result,
+        goldBanked: carried,
+        goldLost: 0,
+        floor: this.dungeon.floor,
+        safeGold: safes.gold,
+        safeCount: safes.count,
+      })
+    },
+
     // 拠点倉庫の所持品を現ランのインベントリへ展開し、装備中ボーナスを再適用（ラン開始時）
     loadBelongingsIntoInventory() {
       this.inventory = JSON.parse(JSON.stringify(this.meta.storage))


### PR DESCRIPTION
## 概要

直前の code-review（修正コミット fef0659 に対する再レビュー）で挙がった4件のうち、**本当に効果のある2件のみ**対応。

## 変更

### #1 ラン終了会計を集約（altitude / 保守性）
脱出(`useGameLoop.escapeDungeon`)・踏破(`DungeonScene` clear handler)で重複し順序も違っていたラン終了処理（金庫精算→gold銀行→装備持ち帰り→lastRun）を **`store.finishSurvivedRun(result)`** に一本化。将来の仕様変更でのドリフトを防止。死亡は損失ロジックが別物のため `applyDeathPenalty` のまま。

### #3 金庫表示の誤解を解消（UX）
`safeResult` が `lastRun` 由来の computed になったことで、拠点を訪れるたびに「謎の金庫を開けた！+NG」が再表示され、今開けたかのように誤認する問題を修正。前回リザルト要約行に **「・ 金庫 +NG」** として統合。未使用の `safeResult` computed と dead CSS も除去。

## 見送った指摘（効果が薄い）
- #2 ワープ巻物の失敗メッセージ非表示 → 床が全占有の時のみ＝実質発生しない
- #4 FOV memo の参照前提 → 現状は floor毎に新配列で安全、直すと過剰設計

## 検証
- `eslint .`: 0 errors（village.vue の self-closing warning は既存・無関係）
- `vitest`: 168 passing
- `vue-tsc --noEmit`: 0 errors
- ブラウザ: 脱出→/village を再確認。metaGold = banked(80) + 金庫(72)、inventory から金庫消費、要約行に「・金庫 +72G」表示。挙動は集約前と同一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ダンジョンを脱出・踏破した際の報酬精算を統一し、獲得したゴールドや謎の金庫の報酬が正しく拠点へ反映されるようになりました。
  * 生還時に装備品が拠点倉庫へ保存され、直近のラン結果にも到達フロアや金庫報酬が正しく記録されます。

* **表示改善**
  * 村画面の直近ラン情報で、謎の金庫から獲得したゴールドをより簡潔に表示するよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->