### PR TITLE
feat(village): 拠点を歩けるPhaserシーンに（トルネコ/ヤンガス風・仮アセット）

### DIFF
--- a/components/VillageCanvas.client.vue
+++ b/components/VillageCanvas.client.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+  import Phaser from 'phaser'
+  import { markRaw, nextTick, onMounted, onUnmounted, ref } from 'vue'
+  import { VillageScene } from '~/phaser/scenes/VillageScene'
+  import { useGameStore } from '~/stores/gameStore'
+
+  const gameContainer = ref<HTMLDivElement | null>(null)
+  let game: Phaser.Game | null = null
+  const gameStore = useGameStore()
+
+  function createGame(parent: HTMLDivElement): Phaser.Game {
+    return new Phaser.Game({
+      type: Phaser.AUTO,
+      parent,
+      width: 480,
+      height: 768,
+      pixelArt: true,
+      scale: {
+        mode: Phaser.Scale.FIT,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+      },
+      callbacks: {
+        preBoot: (g) => {
+          g.registry.set('gameStore', gameStore)
+        },
+      },
+      scene: [VillageScene],
+      backgroundColor: '#1a1a2e',
+    })
+  }
+
+  onMounted(async () => {
+    await nextTick()
+    if (!gameContainer.value) return
+    // 拠点の永続データを localStorage から同期し、施設接触状態をリセット
+    gameStore.loadMeta()
+    gameStore.setVillageFacility(null)
+    game = markRaw(createGame(gameContainer.value))
+  })
+
+  onUnmounted(() => {
+    if (game) {
+      game.destroy(true)
+      game = null
+    }
+  })
+</script>
+
+<template>
+  <div ref="gameContainer" class="game-container" />
+</template>
+
+<style scoped>
+  .game-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+</style>

--- a/game/village/villageMap.ts
+++ b/game/village/villageMap.ts
@@ -1,0 +1,45 @@
+import { TILE, type TileType } from '../data/maps'
+
+// 拠点の施設種別（プレイヤーが乗ると対応UIを開く）
+export type VillageFacilityType = 'blacksmith' | 'dungeon' | 'exit'
+
+export interface VillageFacility {
+  x: number
+  y: number
+  type: VillageFacilityType
+  label: string
+  color: number // マーカー色（仮アセット代わり）
+}
+
+const _ = TILE.FLOOR
+const W = TILE.WALL
+
+// 小さな固定拠点マップ（外周＋内部の柱で町らしさを出す）。13x11。
+// スクロールせず全体を1画面に収める前提のサイズ。
+// prettier-ignore
+export const VILLAGE_MAP: TileType[][] = [
+  [W, W, W, W, W, W, W, W, W, W, W, W, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, W, _, _, _, W, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, W, _, _, _, W, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, _, _, _, _, _, _, _, _, _, _, _, W],
+  [W, W, W, W, W, W, W, W, W, W, W, W, W],
+]
+
+export const VILLAGE_PLAYER_START = { x: 6, y: 5 }
+
+// 施設は歩ける床タイル上に配置し、乗ると開く
+export const VILLAGE_FACILITIES: VillageFacility[] = [
+  { x: 2, y: 2, type: 'blacksmith', label: '鍛冶屋', color: 0xd98a3a },
+  { x: 10, y: 2, type: 'dungeon', label: 'ダンジョン', color: 0x8a6bd9 },
+  { x: 6, y: 9, type: 'exit', label: '出口', color: 0x9aa0a6 },
+]
+
+export function facilityAt(x: number, y: number): VillageFacility | undefined {
+  return VILLAGE_FACILITIES.find((f) => f.x === x && f.y === y)
+}

--- a/pages/village.vue
+++ b/pages/village.vue
@@ -1,19 +1,25 @@
 <script setup lang="ts">
-  import { computed, onMounted, ref } from 'vue'
+  import { computed, onMounted, ref, watch } from 'vue'
   import { useGameStore } from '~/stores/gameStore'
   import { DUNGEONS, DEFAULT_DUNGEON_ID } from '~/game/dungeon'
   import { ITEMS } from '~/game/data/items'
   import { computeEnhanceCost } from '~/game/systems/EconomySystem'
   import gameConfig from '~/game/data/gameConfig.json'
 
-  // 拠点画面（村）: 脱出・帰還の行き先、永続ゴールドの表示、鍛冶、ダンジョンへの出発
+  // 拠点画面（村）: 歩けるPhaserの町 + 施設に乗ると開くモーダル（鍛冶 / ダンジョン選択 / 出口）
   const router = useRouter()
   const gameStore = useGameStore()
 
   const equipCfg = gameConfig.equipmentConfig
 
   const gold = computed(() => gameStore.meta.gold)
-  const lastRun = computed(() => gameStore.meta.lastRun)
+
+  // 接触中の施設（VillageScene が store 経由で設定）
+  const facility = computed(() => gameStore.villageFacility)
+  const closeFacility = () => {
+    blacksmithMsg.value = ''
+    gameStore.setVillageFacility(null)
+  }
 
   // 鍛冶: 拠点倉庫の装備一覧（強化対象）。index は meta.storage 上の位置。
   const equipmentList = computed(() =>
@@ -24,11 +30,7 @@
         const def = ITEMS[entry.itemId]
         const level = entry.equipmentData?.enhanceLevel ?? 0
         const maxed = level >= equipCfg.maxEnhanceLevel
-        const cost = computeEnhanceCost(
-          level,
-          equipCfg.enhanceCostBase,
-          equipCfg.enhanceCostMultiplier
-        )
+        const cost = computeEnhanceCost(level, equipCfg.enhanceCostBase, equipCfg.enhanceCostMultiplier)
         return {
           index,
           name: def?.name ?? entry.itemId,
@@ -41,191 +43,158 @@
   )
 
   const blacksmithMsg = ref('')
-
   const enhance = (index: number) => {
     const result = gameStore.enhanceEquipment(index)
     blacksmithMsg.value = result.message
   }
 
-  const lastRunLabel = computed(() => {
-    const r = lastRun.value
-    if (!r) return ''
-    if (r.result === 'escaped') return '生還'
-    if (r.result === 'cleared') return '踏破'
-    return '力尽きた'
-  })
-
   const dungeonList = computed(() =>
-    Object.values(DUNGEONS).map((d) => ({
-      id: d.id,
-      name: d.name,
-      floors: d.floors.length,
-    }))
+    Object.values(DUNGEONS).map((d) => ({ id: d.id, name: d.name, floors: d.floors.length }))
   )
-
   const selectedDungeonId = ref(DEFAULT_DUNGEON_ID)
-
-  onMounted(() => {
-    // localStorage から永続データを同期
-    gameStore.loadMeta()
-  })
 
   const departDungeon = () => {
     const dungeon = DUNGEONS[selectedDungeonId.value] ?? DUNGEONS[DEFAULT_DUNGEON_ID]
-    // 選択したダンジョンをストアに設定し、現ランのセッションを破棄して新規開始
+    gameStore.setVillageFacility(null)
     gameStore.setDungeon(dungeon.id, dungeon.floors.length)
     sessionStorage.removeItem('gameState')
     router.push('/game')
   }
 
   const backToTitle = () => {
+    gameStore.setVillageFacility(null)
     router.push('/')
   }
+
+  onMounted(() => {
+    gameStore.loadMeta()
+    gameStore.setVillageFacility(null)
+  })
+
+  // 施設が切り替わったらメッセージをリセット
+  watch(facility, () => {
+    blacksmithMsg.value = ''
+  })
 </script>
 
 <template>
-  <div class="village-screen">
-    <div class="header-area">
-      <h1 class="title">拠点の村</h1>
-      <p class="subtitle nes-text is-disabled">〜 深淵の入口 〜</p>
-    </div>
+  <div class="village-page">
+    <VillageCanvas />
 
-    <!-- 所持金 -->
-    <div class="gold-panel nes-container is-dark is-rounded">
-      <div class="gold-row">
-        <span class="gold-label">所持金</span>
-        <span class="gold-value">{{ gold }} G</span>
+    <!-- 施設モーダル: 町で施設タイルに乗る/A で開く -->
+    <div v-if="facility" class="modal-backdrop" @click.self="closeFacility">
+      <!-- 鍛冶屋 -->
+      <div v-if="facility === 'blacksmith'" class="modal-panel nes-container is-dark is-rounded">
+        <div class="panel-head">
+          <span class="panel-title">鍛冶屋</span>
+          <span class="panel-gold">{{ gold }} G</span>
+        </div>
+        <p v-if="equipmentList.length === 0" class="note nes-text is-disabled">
+          強化できる装備がない
+        </p>
+        <ul v-else class="equip-list">
+          <li v-for="eq in equipmentList" :key="eq.index" class="equip-row">
+            <span class="equip-name">
+              {{ eq.name }}
+              <span v-if="eq.level > 0" class="equip-level">+{{ eq.level }}</span>
+            </span>
+            <button
+              v-if="!eq.maxed"
+              class="nes-btn is-small enhance-btn"
+              :class="{ 'is-disabled': !eq.canAfford }"
+              :disabled="!eq.canAfford"
+              @click="enhance(eq.index)"
+            >
+              強化 {{ eq.cost }}G
+            </button>
+            <span v-else class="equip-maxed nes-text is-disabled">MAX</span>
+          </li>
+        </ul>
+        <p v-if="blacksmithMsg" class="msg">{{ blacksmithMsg }}</p>
+        <button class="nes-btn close-btn" @click="closeFacility">閉じる</button>
       </div>
-      <p v-if="lastRun" class="lastrun" :class="`is-${lastRun.result}`">
-        前回: {{ lastRunLabel }} / B{{ lastRun.floor }}F
-        <template v-if="lastRun.goldBanked > 0"> ・ +{{ lastRun.goldBanked }}G</template>
-        <template v-if="lastRun.goldLost > 0"> ・ -{{ lastRun.goldLost }}G</template>
-        <template v-if="(lastRun.safeGold ?? 0) > 0"> ・ 金庫 +{{ lastRun.safeGold }}G</template>
-      </p>
-    </div>
 
-    <!-- 鍛冶屋: 持ち帰った装備を gold で強化 -->
-    <div class="shop-panel nes-container is-dark is-rounded">
-      <p class="shop-title">鍛冶屋</p>
-      <p v-if="equipmentList.length === 0" class="shop-note nes-text is-disabled">
-        強化できる装備がない
-      </p>
-      <ul v-else class="equip-list">
-        <li v-for="eq in equipmentList" :key="eq.index" class="equip-row">
-          <span class="equip-name">
-            {{ eq.name }}
-            <span v-if="eq.level > 0" class="equip-level">+{{ eq.level }}</span>
-          </span>
-          <button
-            v-if="!eq.maxed"
-            class="nes-btn is-small enhance-btn"
-            :class="{ 'is-disabled': !eq.canAfford }"
-            :disabled="!eq.canAfford"
-            @click="enhance(eq.index)"
+      <!-- ダンジョン入口 -->
+      <div v-else-if="facility === 'dungeon'" class="modal-panel nes-container is-dark is-rounded">
+        <div class="panel-head">
+          <span class="panel-title">どこへ潜る？</span>
+          <span class="panel-gold">{{ gold }} G</span>
+        </div>
+        <div class="dungeon-list">
+          <label
+            v-for="d in dungeonList"
+            :key="d.id"
+            class="dungeon-option"
+            :class="{ 'is-selected': selectedDungeonId === d.id }"
           >
-            強化 {{ eq.cost }}G
-          </button>
-          <span v-else class="equip-maxed nes-text is-disabled">MAX</span>
-        </li>
-      </ul>
-      <p v-if="blacksmithMsg" class="shop-msg">{{ blacksmithMsg }}</p>
-    </div>
-
-    <!-- ダンジョンへ出発 -->
-    <div class="depart-panel nes-container is-dark is-rounded">
-      <p class="depart-title">どこへ潜る？</p>
-      <div class="dungeon-list">
-        <label
-          v-for="d in dungeonList"
-          :key="d.id"
-          class="dungeon-option"
-          :class="{ 'is-selected': selectedDungeonId === d.id }"
-        >
-          <input v-model="selectedDungeonId" type="radio" :value="d.id" class="nes-radio" />
-          <span class="dungeon-name">{{ d.name }}</span>
-          <span class="dungeon-floors">B{{ d.floors }}F</span>
-        </label>
+            <input v-model="selectedDungeonId" type="radio" :value="d.id" class="nes-radio" />
+            <span class="dungeon-name">{{ d.name }}</span>
+            <span class="dungeon-floors">B{{ d.floors }}F</span>
+          </label>
+        </div>
+        <button class="nes-btn is-primary depart-btn" @click="departDungeon">出発</button>
+        <button class="nes-btn close-btn" @click="closeFacility">やめる</button>
       </div>
-      <button class="nes-btn is-primary depart-btn" @click="departDungeon">ダンジョンへ出発</button>
-    </div>
 
-    <div class="menu">
-      <button class="nes-btn menu-btn" @click="backToTitle">タイトルへ</button>
+      <!-- 出口 -->
+      <div v-else-if="facility === 'exit'" class="modal-panel nes-container is-dark is-rounded">
+        <p class="panel-title">タイトルへ戻りますか？</p>
+        <button class="nes-btn is-primary depart-btn" @click="backToTitle">タイトルへ</button>
+        <button class="nes-btn close-btn" @click="closeFacility">やめる</button>
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-  .village-screen {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 1.2rem;
-    min-height: 100vh;
-    min-height: 100dvh;
+  .village-page {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
     background-color: #1a1a2e;
     color: #fff;
-    padding: 2rem 1rem;
     font-family: 'DotGothic16', monospace;
+    overflow: hidden;
   }
 
-  .header-area {
-    text-align: center;
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 20;
+    padding: 1rem;
   }
 
-  .title {
-    font-size: 1.4rem;
-    margin: 0 0 0.3rem;
-  }
-
-  .subtitle {
-    font-size: 0.6rem;
-    margin: 0;
-  }
-
-  .gold-panel,
-  .shop-panel,
-  .depart-panel {
+  .modal-panel {
     width: 100%;
     max-width: 320px;
     padding: 1rem !important;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
   }
 
-  .gold-row {
+  .panel-head {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
+  }
+
+  .panel-title {
     font-size: 0.85rem;
   }
 
-  .gold-value {
+  .panel-gold {
     color: #ffd700;
     font-weight: bold;
+    font-size: 0.8rem;
   }
 
-  .lastrun {
-    margin: 0.6rem 0 0;
-    font-size: 0.6rem;
-    opacity: 0.85;
-  }
-
-  .lastrun.is-escaped,
-  .lastrun.is-cleared {
-    color: #7fdfa0;
-  }
-
-  .lastrun.is-dead {
-    color: #ff8a8a;
-  }
-
-  .shop-title,
-  .depart-title {
-    font-size: 0.75rem;
-    margin: 0 0 0.6rem;
-  }
-
-  .shop-note {
+  .note {
     font-size: 0.6rem;
     margin: 0;
   }
@@ -264,8 +233,8 @@
     font-size: 0.6rem;
   }
 
-  .shop-msg {
-    margin: 0.6rem 0 0;
+  .msg {
+    margin: 0;
     font-size: 0.6rem;
     color: #7fdfa0;
   }
@@ -274,7 +243,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
-    margin-bottom: 0.9rem;
   }
 
   .dungeon-option {
@@ -300,28 +268,13 @@
 
   .depart-btn {
     width: 100%;
-    padding: 0.7rem 1rem !important;
-    font-size: 0.75rem !important;
-  }
-
-  .menu {
-    width: 100%;
-    max-width: 320px;
-  }
-
-  .menu-btn {
-    width: 100%;
     padding: 0.6rem 1rem !important;
-    font-size: 0.7rem !important;
+    font-size: 0.72rem !important;
   }
 
-  @media (min-width: 480px) {
-    .title {
-      font-size: 1.8rem;
-    }
-
-    .gold-row {
-      font-size: 1rem;
-    }
+  .close-btn {
+    width: 100%;
+    padding: 0.5rem 1rem !important;
+    font-size: 0.65rem !important;
   }
 </style>

--- a/phaser/scenes/VillageScene.ts
+++ b/phaser/scenes/VillageScene.ts
@@ -1,0 +1,307 @@
+import Phaser from 'phaser'
+import { TILE } from '../../game/data/maps'
+import { canMoveDiagonally } from '../../game/systems/movement'
+import {
+  VILLAGE_MAP,
+  VILLAGE_PLAYER_START,
+  VILLAGE_FACILITIES,
+  facilityAt,
+  type VillageFacility,
+} from '../../game/village/villageMap'
+import { Controller } from '../ui/Controller'
+
+/**
+ * 拠点(村)の歩けるシーン。ダンジョンのように8方向移動でき、施設タイルに乗る/A で
+ * 施設UI（Vue モーダル）を開く。戦闘・敵・FOV・ターンは無い軽量シーン。
+ * 施設の接触は store.villageFacility 経由で village.vue に伝える。
+ */
+export class VillageScene extends Phaser.Scene {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private gameStore: any = null
+
+  private readonly map = VILLAGE_MAP
+  private readonly mapW = VILLAGE_MAP[0].length
+  private readonly mapH = VILLAGE_MAP.length
+
+  private tileSize = 32
+  private offsetX = 0
+  private offsetY = 0
+
+  private mapContainer!: Phaser.GameObjects.Container
+  private entityContainer!: Phaser.GameObjects.Container
+  private player!: Phaser.GameObjects.Sprite
+  private goldText!: Phaser.GameObjects.Text
+
+  private px = VILLAGE_PLAYER_START.x
+  private py = VILLAGE_PLAYER_START.y
+
+  // 8方向入力（同フレーム合成 / rAF）
+  private static readonly MOVE_KEYS = [
+    'ArrowUp',
+    'KeyW',
+    'ArrowDown',
+    'KeyS',
+    'ArrowLeft',
+    'KeyA',
+    'ArrowRight',
+    'KeyD',
+  ]
+  private heldMoveKeys = new Set<string>()
+  private pendingMove: { dx: number; dy: number } | null = null
+  private movePending = false
+  private moveRafId = 0
+
+  private lastGold = -1
+
+  constructor() {
+    super({ key: 'VillageScene' })
+  }
+
+  preload() {
+    for (let i = 1; i <= 8; i++) {
+      this.load.image(`floor_${i}`, `/assets/tiles/floor_${i}.png`)
+    }
+    this.load.image('wall_mid', '/assets/tiles/wall_mid.png')
+    for (let i = 0; i <= 3; i++) {
+      this.load.image(`knight_f${i}`, `/assets/tiles/knight_m_idle_anim_f${i}.png`)
+    }
+  }
+
+  create() {
+    this.gameStore = this.game.registry.get('gameStore')
+    this.px = VILLAGE_PLAYER_START.x
+    this.py = VILLAGE_PLAYER_START.y
+    this.gameStore?.setVillageFacility(null)
+
+    this.calculateLayout()
+
+    this.mapContainer = this.add.container(0, 0)
+    this.entityContainer = this.add.container(0, 0)
+
+    if (!this.anims.exists('knight_idle_anim')) {
+      this.anims.create({
+        key: 'knight_idle_anim',
+        frames: [{ key: 'knight_f0' }, { key: 'knight_f1' }, { key: 'knight_f2' }, { key: 'knight_f3' }],
+        frameRate: 6,
+        repeat: -1,
+      })
+    }
+
+    this.drawMap()
+    this.drawPlayer()
+    this.createHud()
+    this.setupKeyboard()
+
+    // 仮想コントローラ（ダンジョンと同じもの）。A/Enter で施設を開く。
+    new Controller(
+      this,
+      (dx, dy) => this.tryMove(dx, dy),
+      (action) => this.onAction(action)
+    )
+  }
+
+  // 全マップをステータスバー(上)とコントローラ(下)の間に収める
+  private calculateLayout() {
+    const areaTop = 60
+    const areaBottom = 430
+    const availW = 480 - 24
+    const availH = areaBottom - areaTop
+    this.tileSize = Math.floor(Math.min(availW / this.mapW, availH / this.mapH))
+    const mapPxW = this.tileSize * this.mapW
+    const mapPxH = this.tileSize * this.mapH
+    this.offsetX = Math.floor((480 - mapPxW) / 2)
+    this.offsetY = areaTop + Math.floor((availH - mapPxH) / 2)
+  }
+
+  private cx(x: number): number {
+    return this.offsetX + x * this.tileSize + this.tileSize / 2
+  }
+
+  private cy(y: number): number {
+    return this.offsetY + y * this.tileSize + this.tileSize / 2
+  }
+
+  private drawMap() {
+    this.mapContainer.removeAll(true)
+    for (let y = 0; y < this.mapH; y++) {
+      for (let x = 0; x < this.mapW; x++) {
+        const sx = this.cx(x)
+        const sy = this.cy(y)
+        if (this.map[y][x] === TILE.WALL) {
+          const wall = this.add.image(sx, sy, 'wall_mid').setDisplaySize(this.tileSize, this.tileSize)
+          this.mapContainer.add(wall)
+        } else {
+          const key = `floor_${((x * 7 + y * 13) % 8) + 1}`
+          const floor = this.add.image(sx, sy, key).setDisplaySize(this.tileSize, this.tileSize)
+          this.mapContainer.add(floor)
+        }
+      }
+    }
+    // 施設マーカー（仮アセット: 色付き角丸 + ラベル）
+    for (const f of VILLAGE_FACILITIES) {
+      this.drawFacility(f)
+    }
+  }
+
+  private drawFacility(f: VillageFacility) {
+    const sx = this.cx(f.x)
+    const sy = this.cy(f.y)
+    const s = this.tileSize
+    const g = this.add.graphics()
+    g.fillStyle(f.color, 0.85)
+    g.fillRoundedRect(sx - s / 2 + 3, sy - s / 2 + 3, s - 6, s - 6, 4)
+    g.lineStyle(2, 0xffffff, 0.9)
+    g.strokeRoundedRect(sx - s / 2 + 3, sy - s / 2 + 3, s - 6, s - 6, 4)
+    this.mapContainer.add(g)
+    const label = this.add
+      .text(sx, sy + s / 2 + 7, f.label, {
+        fontSize: '10px',
+        color: '#ffffff',
+        fontFamily: '"DotGothic16", monospace',
+      })
+      .setOrigin(0.5, 0.5)
+    this.mapContainer.add(label)
+  }
+
+  private drawPlayer() {
+    this.player = this.add
+      .sprite(this.cx(this.px), this.cy(this.py), 'knight_f0')
+      .setDisplaySize(this.tileSize * 0.9, this.tileSize * 0.9)
+      .play('knight_idle_anim')
+    this.entityContainer.add(this.player)
+  }
+
+  private createHud() {
+    this.add.rectangle(240, 30, 480, 52, 0x000000, 0.55).setOrigin(0.5, 0.5)
+    this.add
+      .text(16, 20, '拠点の村', {
+        fontSize: '14px',
+        color: '#ffffff',
+        fontFamily: '"DotGothic16", monospace',
+      })
+      .setOrigin(0, 0.5)
+    this.goldText = this.add
+      .text(464, 20, '', {
+        fontSize: '14px',
+        color: '#ffd700',
+        fontFamily: '"DotGothic16", monospace',
+      })
+      .setOrigin(1, 0.5)
+    // 前回リザルトの一言サマリ（生還/踏破/力尽きた）
+    this.add
+      .text(16, 41, this.formatLastRun(), {
+        fontSize: '10px',
+        color: '#9fe6b4',
+        fontFamily: '"DotGothic16", monospace',
+      })
+      .setOrigin(0, 0.5)
+    this.updateHud()
+  }
+
+  private formatLastRun(): string {
+    const r = this.gameStore?.meta?.lastRun
+    if (!r) return ''
+    const label = r.result === 'escaped' ? '生還' : r.result === 'cleared' ? '踏破' : '力尽きた'
+    const parts = [`前回: ${label} / B${r.floor}F`]
+    if (r.goldBanked > 0) parts.push(`+${r.goldBanked}G`)
+    if (r.goldLost > 0) parts.push(`-${r.goldLost}G`)
+    if ((r.safeGold ?? 0) > 0) parts.push(`金庫 +${r.safeGold}G`)
+    return parts.join(' ・ ')
+  }
+
+  private updateHud() {
+    const gold = this.gameStore?.meta?.gold ?? 0
+    this.goldText.setText(`${gold} G`)
+    this.lastGold = gold
+  }
+
+  override update() {
+    // 鍛冶などで gold が変わったら追従
+    const gold = this.gameStore?.meta?.gold ?? 0
+    if (gold !== this.lastGold) this.updateHud()
+  }
+
+  private modalOpen(): boolean {
+    return !!this.gameStore?.villageFacility
+  }
+
+  // --- 入力 ---
+  private setupKeyboard() {
+    const keyboard = this.input.keyboard
+    if (!keyboard) return
+    keyboard.on('keydown', (e: KeyboardEvent) => {
+      if (e.code === 'Enter') {
+        this.onAction('confirm')
+        return
+      }
+      if (VillageScene.MOVE_KEYS.includes(e.code)) {
+        this.heldMoveKeys.add(e.code)
+        this.pendingMove = this.composeMoveDirection()
+        this.scheduleMove()
+      }
+    })
+    keyboard.on('keyup', (e: KeyboardEvent) => this.heldMoveKeys.delete(e.code))
+    this.game.events.on(Phaser.Core.Events.BLUR, this.clearHeldMoveKeys, this)
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.game.events.off(Phaser.Core.Events.BLUR, this.clearHeldMoveKeys, this)
+      cancelAnimationFrame(this.moveRafId)
+      this.heldMoveKeys.clear()
+      this.pendingMove = null
+      this.movePending = false
+    })
+  }
+
+  private clearHeldMoveKeys() {
+    this.heldMoveKeys.clear()
+    this.pendingMove = null
+  }
+
+  private composeMoveDirection(): { dx: number; dy: number } {
+    let dx = 0
+    let dy = 0
+    const k = this.heldMoveKeys
+    if (k.has('ArrowUp') || k.has('KeyW')) dy -= 1
+    if (k.has('ArrowDown') || k.has('KeyS')) dy += 1
+    if (k.has('ArrowLeft') || k.has('KeyA')) dx -= 1
+    if (k.has('ArrowRight') || k.has('KeyD')) dx += 1
+    return { dx, dy }
+  }
+
+  private scheduleMove() {
+    if (this.movePending) return
+    this.movePending = true
+    this.moveRafId = requestAnimationFrame(() => {
+      this.movePending = false
+      const m = this.pendingMove
+      this.pendingMove = null
+      if (m && (m.dx !== 0 || m.dy !== 0)) this.tryMove(m.dx, m.dy)
+    })
+  }
+
+  private isWalkable(x: number, y: number): boolean {
+    if (y < 0 || y >= this.mapH || x < 0 || x >= this.mapW) return false
+    return this.map[y][x] !== TILE.WALL
+  }
+
+  private tryMove(dx: number, dy: number) {
+    if (this.modalOpen()) return // モーダル表示中は移動しない
+    const nx = this.px + dx
+    const ny = this.py + dy
+    if (!this.isWalkable(nx, ny)) return
+    if (dx !== 0 && dy !== 0 && !canMoveDiagonally(this.map, this.px, this.py, dx, dy)) return
+    this.px = nx
+    this.py = ny
+    this.player.setPosition(this.cx(this.px), this.cy(this.py))
+    // 施設タイルに乗ったら開く
+    const f = facilityAt(this.px, this.py)
+    if (f) this.gameStore?.setVillageFacility(f.type)
+  }
+
+  private onAction(action: string) {
+    if (action !== 'confirm') return // 村では A/Enter のみ使用（他ボタンは無効）
+    if (this.modalOpen()) return
+    // 足元の施設を開く（乗って閉じた後の再オープン用）
+    const f = facilityAt(this.px, this.py)
+    if (f) this.gameStore?.setVillageFacility(f.type)
+  }
+}

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -108,6 +108,7 @@ interface GameState {
   defeatedEnemies: number
   maxFloorReached: number
   meta: MetaState // ラン跨ぎ永続データ
+  villageFacility: string | null // 拠点で接触中の施設（'blacksmith'|'dungeon'|'exit'|null）。VillageScene→village.vue の橋渡し
 }
 
 export const useGameStore = defineStore('game', {
@@ -147,6 +148,7 @@ export const useGameStore = defineStore('game', {
       lastRun: null,
       storage: [],
     },
+    villageFacility: null,
   }),
 
   getters: {
@@ -186,6 +188,11 @@ export const useGameStore = defineStore('game', {
 
     setGameResult(result: GameResult) {
       this.gameResult = result
+    },
+
+    // 拠点で接触中の施設を設定（VillageScene が呼び、village.vue がモーダル表示に使う）
+    setVillageFacility(facility: string | null) {
+      this.villageFacility = facility
     },
 
     incrementDefeatedEnemies() {


### PR DESCRIPTION
## 概要

拠点(村)を、ダンジョンと同じように**コントローラで歩き回れるPhaserシーン**に刷新。トルネコ/ヤンガス風。施設に歩いて行って開く。アセットが無いため**仮（色マーカー＋ラベル）**で実装。

## 実装

- **`phaser/scenes/VillageScene.ts`**(新規): 固定の町マップを1画面表示。8方向コントローラ/キーボード移動（`canMoveDiagonally` 流用、壁角すり抜け禁止）。施設タイル(鍛冶屋/ダンジョン入口/出口)に**乗る or Aボタン**でUIを開く。戦闘・敵・FOV・ターン無しの軽量シーン。
- **`game/village/villageMap.ts`**(新規): 町マップ(`number[][]`)＋playerStart＋施設座標。Phaser非依存データ。
- **`components/VillageCanvas.client.vue`**(新規): `/village` で Phaser を起動し `gameStore` を registry 注入。
- **`pages/village.vue`**: 静的ボタンUI → 「歩ける町＋施設モーダル」構成へ。鍛冶(強化)・ダンジョン選択+出発・出口(タイトル)は**既存ロジックを再利用**しモーダル化。
- **`stores/gameStore.ts`**: `villageFacility` 状態 + `setVillageFacility`（VillageScene→village.vue の橋渡し）。
- HUDに所持金＋前回リザルトを表示。

## 仮アセット / 割り切り
- 施設は専用スプライトが無いため**色付き角丸＋日本語ラベル**（橙=鍛冶屋 / 紫=ダンジョン / 灰=出口）。歩ける床タイル上に配置。
- コントローラは既存 `Controller` を流用（L/R/SELECT/START は村では無効）。
- ダンジョン(`DungeonScene`)には未変更＝既存挙動に影響なし。

## 検証
- `eslint .`: 0 errors（既存の `<input/>` self-closing warning のみ）
- `vitest`: 168 passing / `vue-tsc`: 0 errors
- ブラウザ: 町を歩行 → 鍛冶屋タイルに到達→モーダル（剣+1・300G）→強化150Gで+2 → 閉じる → ダンジョン入口へ歩行→選択モーダル。エラーゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)