### PR TITLE
fix(economy)+feat: 持ち物/gold引き継ぎ・死亡半減・はじめから刷新・音量設定

### DIFF
--- a/components/GameCanvas.client.vue
+++ b/components/GameCanvas.client.vue
@@ -38,14 +38,15 @@
     await nextTick()
     if (!gameContainer.value) return
 
-    // sessionStorageから状態を復元、なければ新規初期化
+    // sessionStorageから状態を復元
     const restored = gameStore.restoreFromSession()
+    // 拠点の永続データ（gold/持ち物）は localStorage を正として先に同期する。
+    // 新規ダイブ時の initDungeon→loadBelongings が meta を参照するため、必ず initDungeon より前に。
+    gameStore.loadMeta()
+    // 復元できていなければ新規初期化（meta から持ち物・ゴールドを引き継ぐ）
     if (!restored || gameStore.currentMap.length === 0) {
       gameLoop.initDungeon(gameStore.dungeon.dungeonId)
     }
-
-    // 拠点の永続データ（gold等）は localStorage を正として同期（session復元より優先）
-    gameStore.loadMeta()
 
     // 復元時にゲーム終了状態ならリザルト/拠点へ直接遷移
     if (gameStore.gameResult === 'escaped') {

--- a/components/GameCanvas.client.vue
+++ b/components/GameCanvas.client.vue
@@ -4,11 +4,13 @@
   import { DungeonScene } from '~/phaser/scenes/DungeonScene'
   import { UIScene } from '~/phaser/scenes/UIScene'
   import { useGameStore } from '~/stores/gameStore'
+  import { useSettingsStore } from '~/stores/settingsStore'
   import { useGameLoop } from '~/composables/useGameLoop'
 
   const gameContainer = ref<HTMLDivElement | null>(null)
   let game: Phaser.Game | null = null
   const gameStore = useGameStore()
+  const settings = useSettingsStore()
   const gameLoop = useGameLoop()
   const router = useRouter()
 
@@ -27,6 +29,7 @@
         preBoot: (g) => {
           g.registry.set('gameStore', gameStore)
           g.registry.set('gameLoop', gameLoop)
+          g.registry.set('settingsStore', settings)
         },
       },
       scene: [DungeonScene, UIScene],
@@ -37,6 +40,9 @@
   onMounted(async () => {
     await nextTick()
     if (!gameContainer.value) return
+
+    // ユーザー設定（音量）を localStorage から読み込む（Phaser 起動前）
+    settings.load()
 
     // sessionStorageから状態を復元
     const restored = gameStore.restoreFromSession()

--- a/game/data/gameConfig.json
+++ b/game/data/gameConfig.json
@@ -49,7 +49,7 @@
     "dropChance": 0.6
   },
   "deathPenalty": {
-    "goldLossRate": 1.0
+    "goldLossRate": 0.5
   },
   "strangeSafe": {
     "minGold": 50,

--- a/game/systems/EconomySystem.ts
+++ b/game/systems/EconomySystem.ts
@@ -33,3 +33,26 @@ export function computeEnhanceCost(currentLevel: number, base: number, multiplie
   const lvl = Math.max(0, Math.floor(currentLevel))
   return Math.floor(base * Math.pow(multiplier, lvl))
 }
+
+// 死亡時のアイテム分割: 所持アイテムの半分（floor(n/2)）をランダムに失い、残りを持ち帰る。
+// rng は 0<=x<1 を返す関数（テスト時に注入可能）。純粋関数（引数を破壊しない）。
+export function splitItemsOnDeath<T>(
+  items: T[],
+  rng: () => number = Math.random
+): { kept: T[]; lost: T[] } {
+  const n = items.length
+  const lostCount = Math.floor(n / 2)
+  if (lostCount <= 0) return { kept: [...items], lost: [] }
+
+  // Fisher-Yates の部分シャッフルで失う lostCount 個の index を選ぶ
+  const indices = items.map((_, i) => i)
+  for (let i = 0; i < lostCount; i++) {
+    const j = i + Math.floor(rng() * (n - i))
+    ;[indices[i], indices[j]] = [indices[j], indices[i]]
+  }
+  const lostSet = new Set(indices.slice(0, lostCount))
+  const kept: T[] = []
+  const lost: T[] = []
+  items.forEach((item, i) => (lostSet.has(i) ? lost : kept).push(item))
+  return { kept, lost }
+}

--- a/pages/gameover.vue
+++ b/pages/gameover.vue
@@ -20,6 +20,7 @@
   const goldBanked = computed(() => gameStore.meta.lastRun?.goldBanked ?? 0)
   const goldLabel = computed(() => (isDead.value ? '失ったゴールド' : '持ち帰ったゴールド'))
   const goldValue = computed(() => (isDead.value ? goldLost.value : goldBanked.value))
+  const itemsLost = computed(() => gameStore.meta.lastRun?.itemsLost ?? 0)
 
   onMounted(() => {
     // 不正遷移対策: activeのままならタイトルへ戻す
@@ -65,6 +66,10 @@
         <div class="stat-row">
           <dt>{{ goldLabel }}</dt>
           <dd :class="{ 'gold-lost': isDead, 'gold-kept': !isDead }">{{ goldValue }} G</dd>
+        </div>
+        <div v-if="isDead && itemsLost > 0" class="stat-row">
+          <dt>失った道具</dt>
+          <dd class="gold-lost">{{ itemsLost }} 個</dd>
         </div>
       </dl>
     </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,6 +18,10 @@
     router.push('/village')
   }
 
+  const openSettings = () => {
+    router.push('/settings')
+  }
+
   // セーブデータ（永続データ）の有無
   const hasSaveData = ref(false)
   onMounted(() => {
@@ -45,7 +49,7 @@
       >
         つづきから
       </button>
-      <button class="nes-btn menu-btn is-disabled" disabled>せってい</button>
+      <button class="nes-btn menu-btn" @click="openSettings">せってい</button>
     </div>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,23 +1,29 @@
 <script setup lang="ts">
+  import { onMounted, ref } from 'vue'
+  import { useGameStore } from '~/stores/gameStore'
+
   // タイトル画面
   const router = useRouter()
+  const gameStore = useGameStore()
 
+  // はじめから: 永続データ(meta/localStorage)を含め全リセットして拠点の村から開始
   const startGame = () => {
+    gameStore.newGame()
     sessionStorage.removeItem('gameState')
-    router.push('/game')
-  }
-
-  const goVillage = () => {
     router.push('/village')
   }
 
+  // つづきから: 保存済みの永続データを引き継いで拠点の村から再開
   const continueGame = () => {
-    // TODO: セーブデータ読み込み
-    router.push('/game')
+    router.push('/village')
   }
 
-  // セーブデータの有無（仮）
+  // セーブデータ（永続データ）の有無
   const hasSaveData = ref(false)
+  onMounted(() => {
+    hasSaveData.value =
+      typeof localStorage !== 'undefined' && !!localStorage.getItem('katabasis_meta')
+  })
 </script>
 
 <template>
@@ -31,7 +37,6 @@
     <!-- メニューボタン -->
     <div class="menu nes-container is-dark is-rounded">
       <button class="nes-btn is-primary menu-btn" @click="startGame">はじめから</button>
-      <button class="nes-btn menu-btn" @click="goVillage">きょてんへ</button>
       <button
         class="nes-btn menu-btn"
         :class="{ 'is-disabled': !hasSaveData }"

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+  import { computed, onMounted } from 'vue'
+  import { useSettingsStore } from '~/stores/settingsStore'
+
+  const router = useRouter()
+  const settings = useSettingsStore()
+
+  onMounted(() => settings.load())
+
+  const bgmPct = computed({
+    get: () => Math.round(settings.bgmVolume * 100),
+    set: (v: number) => settings.setBgmVolume(v / 100),
+  })
+  const sePct = computed({
+    get: () => Math.round(settings.seVolume * 100),
+    set: (v: number) => settings.setSeVolume(v / 100),
+  })
+
+  // 効果音は音量変更を離した時にサンプル再生してフィードバック
+  const previewSe = () => {
+    if (typeof Audio === 'undefined') return
+    const a = new Audio('/assets/se/item_get.mp3')
+    a.volume = settings.seVolume
+    a.play().catch(() => {})
+  }
+
+  const back = () => router.push('/')
+</script>
+
+<template>
+  <div class="settings-screen">
+    <div class="header">
+      <h1 class="title">せってい</h1>
+    </div>
+
+    <div class="panel nes-container is-dark is-rounded">
+      <div class="row">
+        <label class="row-label">BGM 音量</label>
+        <div class="control">
+          <input v-model.number="bgmPct" type="range" min="0" max="100" step="5" class="slider" />
+          <span class="val">{{ bgmPct }}</span>
+        </div>
+      </div>
+
+      <div class="row">
+        <label class="row-label">こうか音 音量</label>
+        <div class="control">
+          <input
+            v-model.number="sePct"
+            type="range"
+            min="0"
+            max="100"
+            step="5"
+            class="slider"
+            @change="previewSe"
+          />
+          <span class="val">{{ sePct }}</span>
+        </div>
+      </div>
+    </div>
+
+    <button class="nes-btn is-primary back-btn" @click="back">もどる</button>
+  </div>
+</template>
+
+<style scoped>
+  .settings-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background-color: #1a1a2e;
+    color: #fff;
+    padding: 2rem 1rem;
+    font-family: 'DotGothic16', monospace;
+  }
+
+  .title {
+    font-size: 1.4rem;
+    margin: 0;
+  }
+
+  .panel {
+    width: 100%;
+    max-width: 340px;
+    padding: 1.2rem !important;
+    display: flex;
+    flex-direction: column;
+    gap: 1.4rem;
+  }
+
+  .row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .row-label {
+    font-size: 0.72rem;
+  }
+
+  .control {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  .slider {
+    flex: 1;
+    accent-color: #ffd700;
+  }
+
+  .val {
+    width: 2.5rem;
+    text-align: right;
+    color: #ffd700;
+    font-size: 0.8rem;
+  }
+
+  .back-btn {
+    width: 100%;
+    max-width: 340px;
+    padding: 0.7rem 1rem !important;
+    font-size: 0.8rem !important;
+  }
+</style>

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -22,6 +22,10 @@ export class DungeonScene extends BaseMapScene {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private gameLoop: any = null
 
+  // ユーザー設定（音量）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private settings: any = null
+
   // デバッググリッド
   private debugContainer!: Phaser.GameObjects.Container
   private debugGridVisible = false
@@ -71,6 +75,7 @@ export class DungeonScene extends BaseMapScene {
   create() {
     this.gameStore = this.game.registry.get('gameStore')
     this.gameLoop = this.game.registry.get('gameLoop')
+    this.settings = this.game.registry.get('settingsStore')
 
     if (!this.gameStore || !this.gameLoop) {
       throw new Error('gameStore or gameLoop not found in registry')
@@ -557,8 +562,9 @@ export class DungeonScene extends BaseMapScene {
   // --- 戦闘演出 ---
 
   private playSE(key: string) {
-    if (this.cache.audio.exists(key)) {
-      this.sound.play(key, { volume: 0.5 })
+    const volume = this.settings?.seVolume ?? 0.5
+    if (volume > 0 && this.cache.audio.exists(key)) {
+      this.sound.play(key, { volume })
     }
   }
 
@@ -829,10 +835,10 @@ export class DungeonScene extends BaseMapScene {
     this.currentBgm = this.sound.add(key, { loop: true, volume: 0 })
     this.currentBgm.play()
     this.currentBgmKey = key
-    // フェードイン
+    // フェードイン（設定音量まで）
     this.tweens.add({
       targets: this.currentBgm,
-      volume: 0.3,
+      volume: this.settings?.bgmVolume ?? 0.3,
       duration: 1000,
       ease: 'Linear',
     })
@@ -865,7 +871,7 @@ export class DungeonScene extends BaseMapScene {
     this.currentBgm.resume()
     this.tweens.add({
       targets: this.currentBgm,
-      volume: 0.3,
+      volume: this.settings?.bgmVolume ?? 0.3,
       duration: 800,
       ease: 'Linear',
     })

--- a/phaser/scenes/DungeonScene.ts
+++ b/phaser/scenes/DungeonScene.ts
@@ -594,8 +594,7 @@ export class DungeonScene extends BaseMapScene {
     this.inputLocked = true
     this.stopBgm()
     this.playSE('se_game_over')
-    // 持ち物全ロスト (issue #7) + gold ロスト (死亡ペナルティ, issue #37)
-    this.gameStore.clearInventory()
+    // 死亡ペナルティ: ゴールドとアイテムの半分をロスト（applyDeathPenalty が inventory/gold を処理）
     this.gameStore.applyDeathPenalty()
 
     // プレイヤー位置に赤フラッシュ

--- a/phaser/scenes/UIScene.ts
+++ b/phaser/scenes/UIScene.ts
@@ -42,6 +42,20 @@ export class UIScene extends Phaser.Scene {
     this.inventory = new InventoryOverlay(this)
     this.listMenu = new ListMenuOverlay(this)
 
+    // HUD をストアの現在値で初期化（最初の1手を待たずに正しい HP/Lv/満腹/ゴールドを表示する）
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = this.game.registry.get('gameStore') as any
+    if (store) {
+      this.statusBar.updateHP(store.player.hp, store.player.maxHp)
+      this.statusBar.updateLevel(store.player.level)
+      this.statusBar.updateSatiation(store.player.satiation, store.player.maxSatiation)
+      this.statusBar.updateFloor(store.dungeon.floor)
+      // 拠点は永続ゴールド(meta.gold)、ダンジョンは現ランのゴールド(player.gold)を表示
+      const gold =
+        this.gameplayKey === 'VillageScene' ? (store.meta?.gold ?? 0) : (store.player.gold ?? 0)
+      this.statusBar.updateGold(gold)
+    }
+
     // 初期メッセージ（ダンジョンのみ）
     if (this.gameplayKey === 'DungeonScene') {
       this.addMessage('ダンジョンに足を踏み入れた！')

--- a/phaser/ui/InventoryOverlay.ts
+++ b/phaser/ui/InventoryOverlay.ts
@@ -1,6 +1,7 @@
 import type Phaser from 'phaser'
 import { TEXT_COLOR, UI_COLOR } from '../../game/data/colors'
-import { ITEMS } from '../../game/data/items'
+import { ITEMS, computeEquipmentStats } from '../../game/data/items'
+import gameConfig from '../../game/data/gameConfig.json'
 
 const BASE_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
   fontSize: '14px',
@@ -195,6 +196,18 @@ export class InventoryOverlay {
     const def = ITEMS[entry.itemId]
     if (!def) {
       this.descText.setText(entry.name)
+      return
+    }
+    // 装備品は強化を反映した実効ステータスを表示（例: 剣+1 → 攻撃力+6）
+    if (def.equippable && def.effect) {
+      const lvl = entry.equipmentData?.enhanceLevel ?? 0
+      const bonusPerLevel = gameConfig.equipmentConfig?.enhanceBonusPerLevel ?? 1
+      const { attackBonus, defenseBonus } = computeEquipmentStats(def, lvl, bonusPerLevel)
+      const stats: string[] = []
+      if (attackBonus > 0) stats.push(`攻撃力+${attackBonus}`)
+      if (defenseBonus > 0) stats.push(`防御力+${defenseBonus}`)
+      const lvlText = lvl > 0 ? `（+${lvl}）` : ''
+      this.descText.setText(`${def.name}${lvlText}：${stats.join(' ') || def.description}`)
       return
     }
     this.descText.setText(`${def.name}：${def.description}`)

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -228,6 +228,14 @@ export const useGameStore = defineStore('game', {
       this.meta = preservedMeta
     },
 
+    // 完全な新規開始（「はじめから」）: 永続データ(meta)と localStorage も含め全リセット
+    newGame() {
+      this.$reset()
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(META_STORAGE_KEY)
+      }
+    },
+
     // --- 拠点永続データ（localStorage レイヤ） ---
 
     persistMeta() {

--- a/stores/gameStore.ts
+++ b/stores/gameStore.ts
@@ -6,6 +6,7 @@ import {
   computeDeathGoldLoss,
   rollSafeGold,
   computeEnhanceCost,
+  splitItemsOnDeath,
 } from '~/game/systems/EconomySystem'
 import { TILE } from '~/game/data/maps'
 import gameConfig from '~/game/data/gameConfig.json'
@@ -71,6 +72,7 @@ interface LastRun {
   floor: number // 到達フロア
   safeGold?: number // 謎の金庫の開封で得たゴールド
   safeCount?: number // 開封した謎の金庫の個数
+  itemsLost?: number // 死亡でロストしたアイテム数
 }
 
 // ラン跨ぎで永続する拠点データ（localStorage 保存）
@@ -251,69 +253,64 @@ export const useGameStore = defineStore('game', {
       }
     },
 
-    // 現ランで稼いだゴールドを拠点（永続）ゴールドへ預ける
-    bankRunGold(): number {
-      const amount = this.player.gold
-      this.meta.gold += amount
-      this.player.gold = 0
-      this.persistMeta()
-      return amount
-    },
-
     setLastRun(info: LastRun) {
       this.meta.lastRun = info
       this.persistMeta()
     },
 
-    // 死亡時のペナルティ適用: 現ランgoldの一定割合をロスト、残りは拠点へ持ち帰る。
-    // 持ち帰り品（storage）も失う = 死亡は全ロスト。
-    applyDeathPenalty(): { lost: number; kept: number } {
-      const rate = gameConfig.deathPenalty?.goldLossRate ?? 1
-      const { lost, kept } = computeDeathGoldLoss(this.player.gold, rate)
-      this.meta.gold += kept
+    // 死亡ペナルティ: 所持ゴールドとアイテムの半分を失い、残り半分を拠点(meta)へ持ち帰る。
+    // 生還時と違い「半分ロスト」。inventory/gold のクリアもここで行う（呼び出し側で別途クリア不要）。
+    applyDeathPenalty(): { goldLost: number; goldKept: number; itemsLost: number } {
+      const rate = gameConfig.deathPenalty?.goldLossRate ?? 0.5
+      const { lost: goldLost, kept: goldKept } = computeDeathGoldLoss(this.player.gold, rate)
+      const { kept: keptItems, lost: lostItems } = splitItemsOnDeath(this.inventory)
+      this.meta.gold = goldKept
+      this.meta.storage = JSON.parse(JSON.stringify(keptItems))
       this.player.gold = 0
-      this.meta.storage = []
+      this.inventory = []
       this.setLastRun({
         result: 'dead',
-        goldBanked: kept,
-        goldLost: lost,
+        goldBanked: goldKept,
+        goldLost,
         floor: this.dungeon.floor,
         safeGold: 0,
         safeCount: 0,
+        itemsLost: lostItems.length,
       })
-      return { lost, kept }
+      return { goldLost, goldKept, itemsLost: lostItems.length }
     },
 
-    // --- 持ち帰り品（belongings）: 脱出/踏破で拠点へ、死亡で消失、次ラン開始時に再装填 ---
+    // --- 持ち物の持ち帰り: 生還で全保持して次ランへ引き継ぎ、死亡で半分ロスト ---
 
-    // 現在の所持品のうち「装備品のみ」を拠点倉庫へ持ち帰る（消耗品・特殊アイテムはランで完結）。
-    // これにより消耗品のラン跨ぎ無限ストックや、謎の金庫の storage 経由での複製を防ぐ。
+    // 現在の所持品を「すべて」拠点倉庫へ持ち帰る（消耗品・特殊アイテム含む）
     saveBelongings() {
-      const equipment = this.inventory.filter((e) => ITEMS[e.itemId]?.equippable)
-      this.meta.storage = JSON.parse(JSON.stringify(equipment))
+      this.meta.storage = JSON.parse(JSON.stringify(this.inventory))
       this.persistMeta()
     },
 
-    // 生還（脱出・踏破）時のラン終了会計を集約: 金庫精算 → ランgold銀行 → 装備持ち帰り → lastRun。
-    // 脱出・踏破の両出口で同一処理を使い、ドリフトを防ぐ。死亡は損失ロジックが別物のため applyDeathPenalty 側。
+    // 生還（脱出・踏破）時のラン終了会計を集約: 金庫精算 → 全アイテム＆ゴールドを拠点へ保持 → lastRun。
+    // 脱出・踏破の両出口で同一処理を使う。死亡は半分ロストのため applyDeathPenalty 側。
     finishSurvivedRun(result: 'escaped' | 'cleared') {
-      const carried = this.player.gold
-      const safes = this.openStrangeSafes()
-      this.bankRunGold()
-      this.saveBelongings()
+      const safes = this.openStrangeSafes() // 金庫を精算して player.gold に加算・inventory から除去
+      this.saveBelongings() // 全アイテムを拠点へ
+      this.meta.gold = this.player.gold // ゴールドも全額持ち帰り
       this.setLastRun({
         result,
-        goldBanked: carried,
+        goldBanked: this.player.gold,
         goldLost: 0,
         floor: this.dungeon.floor,
         safeGold: safes.gold,
         safeCount: safes.count,
+        itemsLost: 0,
       })
+      this.player.gold = 0
+      this.persistMeta()
     },
 
-    // 拠点倉庫の所持品を現ランのインベントリへ展開し、装備中ボーナスを再適用（ラン開始時）
+    // 拠点倉庫の所持品・ゴールドを現ランへ引き継ぐ（ダイブ開始時）。装備中ボーナスを再適用。
     loadBelongingsIntoInventory() {
       this.inventory = JSON.parse(JSON.stringify(this.meta.storage))
+      this.player.gold = this.meta.gold // ゴールドを引き継いでダイブ
       for (const entry of this.inventory) {
         if (!entry.equipped) continue
         const bonus = equipBonusOf(entry)
@@ -531,8 +528,8 @@ export const useGameStore = defineStore('game', {
         return false
       })
       if (count > 0) {
-        this.meta.gold += gold
-        this.persistMeta()
+        // 現ランのゴールドへ加算（finishSurvivedRun が meta.gold へ保持する）
+        this.player.gold += gold
       }
       return { count, gold }
     },

--- a/stores/settingsStore.ts
+++ b/stores/settingsStore.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+
+// オーディオ等のユーザー設定（ゲーム進行とは別レイヤ。localStorage 永続）
+const SETTINGS_KEY = 'katabasis_settings'
+
+interface SettingsState {
+  bgmVolume: number // 0..1
+  seVolume: number // 0..1
+}
+
+function clamp01(v: number): number {
+  if (Number.isNaN(v)) return 0
+  return Math.min(1, Math.max(0, v))
+}
+
+export const useSettingsStore = defineStore('settings', {
+  state: (): SettingsState => ({
+    bgmVolume: 0.3, // 既定は従来のハードコード値に合わせる
+    seVolume: 0.5,
+  }),
+
+  actions: {
+    load() {
+      if (typeof localStorage === 'undefined') return
+      const saved = localStorage.getItem(SETTINGS_KEY)
+      if (!saved) return
+      try {
+        const parsed = JSON.parse(saved)
+        if (typeof parsed.bgmVolume === 'number') this.bgmVolume = clamp01(parsed.bgmVolume)
+        if (typeof parsed.seVolume === 'number') this.seVolume = clamp01(parsed.seVolume)
+      } catch {
+        localStorage.removeItem(SETTINGS_KEY)
+      }
+    },
+
+    setBgmVolume(v: number) {
+      this.bgmVolume = clamp01(v)
+      this.persist()
+    },
+
+    setSeVolume(v: number) {
+      this.seVolume = clamp01(v)
+      this.persist()
+    },
+
+    persist() {
+      if (typeof localStorage === 'undefined') return
+      localStorage.setItem(
+        SETTINGS_KEY,
+        JSON.stringify({ bgmVolume: this.bgmVolume, seVolume: this.seVolume })
+      )
+    },
+  },
+})

--- a/tests/unit/systems/EconomySystem.test.ts
+++ b/tests/unit/systems/EconomySystem.test.ts
@@ -3,6 +3,7 @@ import {
   computeDeathGoldLoss,
   rollSafeGold,
   computeEnhanceCost,
+  splitItemsOnDeath,
 } from '../../../game/systems/EconomySystem'
 
 describe('EconomySystem.computeDeathGoldLoss', () => {
@@ -102,5 +103,54 @@ describe('EconomySystem.computeEnhanceCost', () => {
 
   it('負のレベルは0扱い', () => {
     expect(computeEnhanceCost(-1, 100, 1.5)).toBe(100)
+  })
+})
+
+describe('EconomySystem.computeDeathGoldLoss（半分ロスト rate=0.5）', () => {
+  it('100の半分は 失50/残50', () => {
+    expect(computeDeathGoldLoss(100, 0.5)).toEqual({ lost: 50, kept: 50 })
+  })
+
+  it('奇数7は 失3(切り捨て)/残4', () => {
+    expect(computeDeathGoldLoss(7, 0.5)).toEqual({ lost: 3, kept: 4 })
+  })
+
+  it('0は 失0/残0', () => {
+    expect(computeDeathGoldLoss(0, 0.5)).toEqual({ lost: 0, kept: 0 })
+  })
+})
+
+describe('EconomySystem.splitItemsOnDeath', () => {
+  it('4個は floor(4/2)=2個ロスト・2個保持', () => {
+    const { kept, lost } = splitItemsOnDeath(['a', 'b', 'c', 'd'])
+    expect(lost.length).toBe(2)
+    expect(kept.length).toBe(2)
+  })
+
+  it('1個は 0個ロスト・1個保持（半分に満たない）', () => {
+    expect(splitItemsOnDeath(['a'])).toEqual({ kept: ['a'], lost: [] })
+  })
+
+  it('0個は 双方空', () => {
+    expect(splitItemsOnDeath([])).toEqual({ kept: [], lost: [] })
+  })
+
+  it('kept と lost の和は元集合（重複・欠落なし）', () => {
+    const items = ['a', 'b', 'c', 'd', 'e']
+    const { kept, lost } = splitItemsOnDeath(items)
+    expect([...kept, ...lost].sort()).toEqual([...items].sort())
+    expect(lost.length).toBe(2) // floor(5/2)
+  })
+
+  it('入力配列を破壊しない', () => {
+    const items = ['a', 'b', 'c', 'd']
+    splitItemsOnDeath(items)
+    expect(items).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('rng 注入で決定的（rng=0 なら先頭を失う）', () => {
+    const { kept, lost } = splitItemsOnDeath(['a', 'b', 'c', 'd'], () => 0)
+    expect(lost).toEqual(['a', 'b'])
+    expect(kept).toEqual(['c', 'd'])
   })
 })


### PR DESCRIPTION
## 概要
ローカル確認で見つかった経済まわりの不具合修正と、タイトル刷新・設定画面追加。

## 経済（バグ修正・仕様反映）
- **生還（脱出/踏破）で全アイテム＋ゴールドを拠点へ保持**し、次ダイブへ引き継ぎ（拠点入場でアイテムが消える不具合を修正。saveBelongings を装備限定→全アイテムへ）。
- **ダイブ開始で meta.gold を player.gold へ引き継ぎ**（loadBelongings）。
- **死亡ペナルティ = ゴールド・アイテムとも半分ロスト**（全ロスト→floor(半分)。`splitItemsOnDeath` 追加、goldLossRate 0.5）。gameover に「失った道具 N個」表示。
- run/bank ゴールド二分割を撤去し gold を一本化。
- **GameCanvas: loadMeta を initDungeon より前へ**（/game リロード時に空 meta を読み引き継ぎ失敗する穴を修正）。

## UI
- **HUDゴールドの初期0表示**を修正（UIScene 生成時にストア値で初期化。拠点=meta.gold / ダンジョン=player.gold）。
- **強化装備の説明**を実効ステータス表示に（剣+1→攻撃力+6）。

## タイトル
- **「はじめから」= 永続データ含む全リセット(newGame)→ 最初に村へ**（従来は前回データが残り“続きから”化）。
- **「きょてんへ」削除**。「つづきから」は保存があれば村から再開。

## 設定
- **「せってい」有効化 → /settings**。**BGM/効果音の音量スライダー**（localStorage永続、ゲーム内音量に反映、効果音はプレビュー再生）。

## 検証
- vitest **177 passing** / vue-tsc 0 / eslint 0 errors（range input の self-closing 警告のみ・既存ルール踏襲）。
- 脱出で全保持・8方向・FOV はローカル/実機で確認済み。

※ 別件（メニュー無料脱出と リレミト巻物 の役割重複の整理）は未対応で保留中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - BGM・効果音の音量を設定画面で調整・保存できるようになりました。
  - 装備品の強化後ステータスがインベントリに表示されます。
  - ゲームオーバー画面に失ったアイテム数を表示します。
  - 拠点への移動、ゲーム開始、続きから再開、設定画面への導線を整理しました。

- **改善**
  - 死亡時のゴールド損失が50%に軽減され、所持品は一部のみ失う仕様になりました。
  - 残ったアイテムは拠点に保管されます。
  - ゲーム開始時やUI初期表示で、保存済みの状態が正しく反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->