### PR TITLE
feat(m7): 会話システム + 村NPC（村長）[Phase1/#27]

### DIFF
--- a/game/village/villageMap.ts
+++ b/game/village/villageMap.ts
@@ -45,3 +45,18 @@ export const VILLAGE_FACILITIES: VillageFacility[] = [
 export function facilityAt(x: number, y: number): VillageFacility | undefined {
   return VILLAGE_FACILITIES.find((f) => f.x === x && f.y === y)
 }
+
+// 村のNPC（話しかけ対象）。施設と違い「乗れない」障害物として置き、隣接＋A で会話する。
+export interface VillageNpc {
+  x: number
+  y: number
+  npcId: string
+  name: string
+}
+
+export const VILLAGE_NPCS: VillageNpc[] = [{ x: 6, y: 3, npcId: 'chief', name: '村長' }]
+
+export function npcAt(x: number, y: number): VillageNpc | undefined {
+  return VILLAGE_NPCS.find((n) => n.x === x && n.y === y)
+}
+

--- a/phaser/scenes/BaseMapScene.ts
+++ b/phaser/scenes/BaseMapScene.ts
@@ -434,6 +434,10 @@ export abstract class BaseMapScene extends Phaser.Scene {
       moveListCursor: (dy: number) => void
       selectListItem: () => void
       getListSelectedIndex: () => number
+      showDialog: (lines: { speaker?: string; text: string }[], onDone?: () => void) => void
+      advanceDialog: () => void
+      hideDialog: () => void
+      isDialogOpen: () => boolean
       addMessage: (msg: string) => void
       updateHP: (current: number, max: number) => void
       updateFloor: (floor: number) => void

--- a/phaser/scenes/UIScene.ts
+++ b/phaser/scenes/UIScene.ts
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { MinimapOverlay } from '../ui/MinimapOverlay'
 import { InventoryOverlay, type InventoryEntry } from '../ui/InventoryOverlay'
 import { ListMenuOverlay, type ListRow } from '../ui/ListMenuOverlay'
+import { DialogOverlay, type DialogLine } from '../ui/DialogOverlay'
 
 export class UIScene extends Phaser.Scene {
   private statusBar!: StatusBar
@@ -16,6 +17,7 @@ export class UIScene extends Phaser.Scene {
   private minimap!: MinimapOverlay
   private inventory!: InventoryOverlay
   private listMenu!: ListMenuOverlay
+  private dialog!: DialogOverlay
 
   // 入力イベントの送り先（DungeonScene / VillageScene）
   private gameplayKey = 'DungeonScene'
@@ -41,6 +43,7 @@ export class UIScene extends Phaser.Scene {
     this.minimap = new MinimapOverlay(this)
     this.inventory = new InventoryOverlay(this)
     this.listMenu = new ListMenuOverlay(this)
+    this.dialog = new DialogOverlay(this)
 
     // HUD をストアの現在値で初期化（最初の1手を待たずに正しい HP/Lv/満腹/ゴールドを表示する）
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -202,6 +205,24 @@ export class UIScene extends Phaser.Scene {
 
   getListSelectedIndex(): number {
     return this.listMenu.getSelectedIndex()
+  }
+
+  // --- 会話 ---
+
+  showDialog(lines: DialogLine[], onDone?: () => void) {
+    this.dialog.show(lines, onDone)
+  }
+
+  advanceDialog() {
+    this.dialog.advance()
+  }
+
+  hideDialog() {
+    this.dialog.hide()
+  }
+
+  isDialogOpen(): boolean {
+    return this.dialog.isOpen()
   }
 
   // --- イベント転送（アクティブなゲームプレイシーンへ） ---

--- a/phaser/scenes/VillageScene.ts
+++ b/phaser/scenes/VillageScene.ts
@@ -7,14 +7,27 @@ import {
   VILLAGE_MAP,
   VILLAGE_PLAYER_START,
   VILLAGE_FACILITIES,
+  VILLAGE_NPCS,
   facilityAt,
+  npcAt,
   type VillageFacility,
+  type VillageNpc,
 } from '../../game/village/villageMap'
 import { BaseMapScene } from './BaseMapScene'
 
 interface VillageNav {
   depart: (dungeonId: string) => void
   toTitle: () => void
+}
+
+// 仮の台本（Phase2 で game/story へ移し、物語進捗に連動させる）
+const NPC_DIALOG: Record<string, { speaker: string; text: string }[]> = {
+  chief: [
+    { speaker: '村長', text: '…よく来たな、探索者よ。' },
+    { speaker: '村長', text: 'この村は、地の底へ続く「深淵」の唯一の入口を見張るために築かれた。' },
+    { speaker: '村長', text: '静寂の森、暗黒城、そして深淵。下るほどに、還らぬ者が増えていく。' },
+    { speaker: '村長', text: 'それでも潜るというなら、止めはせぬ。…追って頼みたいこともある。' },
+  ],
 }
 
 /**
@@ -35,6 +48,10 @@ export class VillageScene extends BaseMapScene {
 
   preload() {
     this.loadSharedAssets()
+    // NPC（女性騎士）スプライト
+    for (let i = 0; i <= 3; i++) {
+      this.load.image(`npc_f${i}`, `/assets/tiles/knight_f_idle_anim_f${i}.png`)
+    }
   }
 
   create() {
@@ -51,6 +68,14 @@ export class VillageScene extends BaseMapScene {
     this.calculateTileSize()
     this.createContainers()
     this.createKnightAnimation()
+    if (!this.anims.exists('npc_idle_anim')) {
+      this.anims.create({
+        key: 'npc_idle_anim',
+        frames: [{ key: 'npc_f0' }, { key: 'npc_f1' }, { key: 'npc_f2' }, { key: 'npc_f3' }],
+        frameRate: 6,
+        repeat: -1,
+      })
+    }
     this.drawScene()
     this.setupInput()
     this.setupTouchInput()
@@ -66,6 +91,30 @@ export class VillageScene extends BaseMapScene {
       if (f.x < viewStartX || f.x >= endX || f.y < viewStartY || f.y >= endY) continue
       this.drawFacilityMarker(f, viewStartX, viewStartY)
     }
+    for (const n of VILLAGE_NPCS) {
+      if (n.x < viewStartX || n.x >= endX || n.y < viewStartY || n.y >= endY) continue
+      this.drawNpc(n, viewStartX, viewStartY)
+    }
+  }
+
+  private drawNpc(n: VillageNpc, viewStartX: number, viewStartY: number) {
+    const cx = this.offsetX + (n.x - viewStartX) * this.tileWidth + this.tileWidth / 2
+    const cy = this.offsetY + (n.y - viewStartY) * this.tileHeight + this.tileHeight * 0.8
+    const sprite = this.add.sprite(cx, cy, 'npc_f0')
+    sprite.setOrigin(0.5, 1.0)
+    sprite.setScale(this.tileScale * 0.6)
+    sprite.play('npc_idle_anim')
+    this.entityContainer.add(sprite)
+    const label = this.add
+      .text(cx, cy - this.tileHeight * 0.85, n.name, {
+        fontSize: '10px',
+        color: '#ffe08a',
+        fontFamily: '"DotGothic16", monospace',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5, 1)
+    this.entityContainer.add(label)
   }
 
   private drawFacilityMarker(f: VillageFacility, viewStartX: number, viewStartY: number) {
@@ -102,10 +151,12 @@ export class VillageScene extends BaseMapScene {
       ui.moveListCursor(dy)
       return
     }
+    if (ui.isDialogOpen()) return // 会話中は移動しない（送りは A のみ）
 
     const nx = this.gameStore.player.position.x + dx
     const ny = this.gameStore.player.position.y + dy
     if (!this.isFloor(nx, ny)) return
+    if (npcAt(nx, ny)) return // NPC は障害物（乗れない）
     if (dx !== 0 && dy !== 0 && !canMoveDiagonally(this.map, this.gameStore.player.position.x, this.gameStore.player.position.y, dx, dy)) {
       return
     }
@@ -121,6 +172,10 @@ export class VillageScene extends BaseMapScene {
     if (this.inputLocked) return
     const ui = this.getUiScene()
 
+    if (ui.isDialogOpen()) {
+      if (action === 'confirm') ui.advanceDialog()
+      return
+    }
     if (ui.isConfirmOpen()) {
       if (action === 'confirm') ui.confirmSelect()
       else if (action === 'inventory') ui.hideConfirm()
@@ -132,12 +187,27 @@ export class VillageScene extends BaseMapScene {
       return
     }
 
-    // 何も開いていない: A で足元の施設を開く
+    // 何も開いていない: A で 隣接NPCと会話 or 足元の施設を開く
     if (action === 'confirm') {
       const pos = this.gameStore.player.position
+      const npc = this.adjacentNpc(pos.x, pos.y)
+      if (npc) {
+        this.talkToNpc(npc)
+        return
+      }
       const f = facilityAt(pos.x, pos.y)
       if (f) this.openFacility(f.type)
     }
+  }
+
+  // プレイヤーに隣接（8近傍）するNPCを返す
+  private adjacentNpc(x: number, y: number): VillageNpc | undefined {
+    return VILLAGE_NPCS.find((n) => Math.abs(n.x - x) <= 1 && Math.abs(n.y - y) <= 1)
+  }
+
+  private talkToNpc(npc: VillageNpc) {
+    const lines = NPC_DIALOG[npc.npcId] ?? [{ speaker: npc.name, text: '…' }]
+    this.getUiScene().showDialog(lines)
   }
 
   // --- 施設 ---

--- a/phaser/ui/DialogOverlay.ts
+++ b/phaser/ui/DialogOverlay.ts
@@ -1,0 +1,113 @@
+import type Phaser from 'phaser'
+import { TEXT_COLOR, UI_COLOR } from '../../game/data/colors'
+
+const BASE_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '14px',
+  color: TEXT_COLOR.white,
+  fontFamily: '"DotGothic16", monospace',
+  letterSpacing: 1,
+}
+
+// 1行分の会話（話者名＋本文）
+export interface DialogLine {
+  speaker?: string
+  text: string
+}
+
+/**
+ * 会話ボックス（画面下部）。話者名＋本文を1つずつ逐次送りする。
+ * A/決定 or タップで次へ、最後まで進むと閉じて onDone を呼ぶ。
+ * ConfirmDialog / ListMenuOverlay と同じパネル様式・入力様式（isOpen/決定/閉じる）に揃える。
+ */
+export class DialogOverlay {
+  private container: Phaser.GameObjects.Container
+  private visible = false
+  private speakerText: Phaser.GameObjects.Text
+  private bodyText: Phaser.GameObjects.Text
+  private nextHint: Phaser.GameObjects.Text
+
+  private lines: DialogLine[] = []
+  private index = 0
+  private onDone: (() => void) | null = null
+
+  constructor(scene: Phaser.Scene) {
+    this.container = scene.add.container(0, 0)
+    this.container.setVisible(false)
+    this.container.setDepth(620)
+
+    // 下部の会話パネル（メッセージログ域より少し上・ゲームエリア下寄せ）
+    const panel = scene.add.graphics()
+    panel.fillStyle(UI_COLOR.panelBg, 0.96)
+    panel.fillRoundedRect(16, 300, 448, 104, 8)
+    panel.lineStyle(2, UI_COLOR.panelBorder, 1)
+    panel.strokeRoundedRect(16, 300, 448, 104, 8)
+    this.container.add(panel)
+
+    // 話者名（上部の小さなラベル）
+    this.speakerText = scene.add.text(32, 312, '', {
+      ...BASE_STYLE,
+      fontSize: '13px',
+      color: TEXT_COLOR.subtle,
+      fontStyle: 'bold',
+    })
+    this.container.add(this.speakerText)
+
+    // 本文（折り返し）
+    this.bodyText = scene.add.text(32, 336, '', {
+      ...BASE_STYLE,
+      fontSize: '14px',
+      wordWrap: { width: 416 },
+    })
+    this.container.add(this.bodyText)
+
+    // 送りヒント
+    this.nextHint = scene.add.text(452, 388, '▼', {
+      ...BASE_STYLE,
+      fontSize: '12px',
+      color: TEXT_COLOR.dim,
+    })
+    this.nextHint.setOrigin(1, 1)
+    this.container.add(this.nextHint)
+  }
+
+  show(lines: DialogLine[], onDone?: () => void) {
+    if (lines.length === 0) return
+    this.lines = lines
+    this.index = 0
+    this.onDone = onDone ?? null
+    this.visible = true
+    this.render()
+    this.container.setVisible(true)
+  }
+
+  // 次の行へ。最後だった場合は閉じて onDone を呼ぶ。
+  advance() {
+    if (!this.visible) return
+    if (this.index < this.lines.length - 1) {
+      this.index++
+      this.render()
+    } else {
+      this.hide()
+      const cb = this.onDone
+      this.onDone = null
+      cb?.()
+    }
+  }
+
+  hide() {
+    this.visible = false
+    this.container.setVisible(false)
+  }
+
+  isOpen(): boolean {
+    return this.visible
+  }
+
+  private render() {
+    const line = this.lines[this.index]
+    this.speakerText.setText(line.speaker ?? '')
+    this.bodyText.setText(line.text)
+    const isLast = this.index >= this.lines.length - 1
+    this.nextHint.setText(isLast ? '□' : '▼')
+  }
+}

--- a/phaser/ui/DialogOverlay.ts
+++ b/phaser/ui/DialogOverlay.ts
@@ -35,16 +35,21 @@ export class DialogOverlay {
     this.container.setVisible(false)
     this.container.setDepth(620)
 
-    // 下部の会話パネル（メッセージログ域より少し上・ゲームエリア下寄せ）
+    // 下部の会話パネル（ゲームエリア下部・メッセージログ域 y413 の手前で終える）
+    // 長いセリフ(全角30字前後)が複数行に折り返しても収まる高さを確保する。
+    const px = 12
+    const py = 258
+    const pw = 456
+    const ph = 150
     const panel = scene.add.graphics()
     panel.fillStyle(UI_COLOR.panelBg, 0.96)
-    panel.fillRoundedRect(16, 300, 448, 104, 8)
+    panel.fillRoundedRect(px, py, pw, ph, 8)
     panel.lineStyle(2, UI_COLOR.panelBorder, 1)
-    panel.strokeRoundedRect(16, 300, 448, 104, 8)
+    panel.strokeRoundedRect(px, py, pw, ph, 8)
     this.container.add(panel)
 
     // 話者名（上部の小さなラベル）
-    this.speakerText = scene.add.text(32, 312, '', {
+    this.speakerText = scene.add.text(px + 16, py + 12, '', {
       ...BASE_STYLE,
       fontSize: '13px',
       color: TEXT_COLOR.subtle,
@@ -52,16 +57,18 @@ export class DialogOverlay {
     })
     this.container.add(this.speakerText)
 
-    // 本文（折り返し）
-    this.bodyText = scene.add.text(32, 336, '', {
+    // 本文（折り返し。パネル内幅に収める）
+    this.bodyText = scene.add.text(px + 16, py + 38, '', {
       ...BASE_STYLE,
-      fontSize: '14px',
-      wordWrap: { width: 416 },
+      fontSize: '13px',
+      lineSpacing: 6,
+      // 日本語は空白が無く既定の wordWrap では折り返されないため、文字単位で折り返す
+      wordWrap: { width: pw - 32, useAdvancedWrap: true },
     })
     this.container.add(this.bodyText)
 
-    // 送りヒント
-    this.nextHint = scene.add.text(452, 388, '▼', {
+    // 送りヒント（右下）
+    this.nextHint = scene.add.text(px + pw - 12, py + ph - 10, '▼', {
       ...BASE_STYLE,
       fontSize: '12px',
       color: TEXT_COLOR.dim,

--- a/phaser/ui/DialogOverlay.ts
+++ b/phaser/ui/DialogOverlay.ts
@@ -35,12 +35,12 @@ export class DialogOverlay {
     this.container.setVisible(false)
     this.container.setDepth(620)
 
-    // 下部の会話パネル（ゲームエリア下部・メッセージログ域 y413 の手前で終える）
-    // 長いセリフ(全角30字前後)が複数行に折り返しても収まる高さを確保する。
+    // 下部の会話パネル（メッセージログ域 y413 の手前で終える）。
+    // セリフは全角30字前後・折り返しても最大3行程度なので、それに合わせた高さにする。
     const px = 12
-    const py = 258
+    const py = 304
     const pw = 456
-    const ph = 150
+    const ph = 98
     const panel = scene.add.graphics()
     panel.fillStyle(UI_COLOR.panelBg, 0.96)
     panel.fillRoundedRect(px, py, pw, ph, 8)
@@ -49,7 +49,7 @@ export class DialogOverlay {
     this.container.add(panel)
 
     // 話者名（上部の小さなラベル）
-    this.speakerText = scene.add.text(px + 16, py + 12, '', {
+    this.speakerText = scene.add.text(px + 16, py + 10, '', {
       ...BASE_STYLE,
       fontSize: '13px',
       color: TEXT_COLOR.subtle,
@@ -58,10 +58,10 @@ export class DialogOverlay {
     this.container.add(this.speakerText)
 
     // 本文（折り返し。パネル内幅に収める）
-    this.bodyText = scene.add.text(px + 16, py + 38, '', {
+    this.bodyText = scene.add.text(px + 16, py + 32, '', {
       ...BASE_STYLE,
       fontSize: '13px',
-      lineSpacing: 6,
+      lineSpacing: 5,
       // 日本語は空白が無く既定の wordWrap では折り返されないため、文字単位で折り返す
       wordWrap: { width: pw - 32, useAdvancedWrap: true },
     })


### PR DESCRIPTION
M7 Phase1（#27 NPC会話・ダイアログシステム）。

- **DialogOverlay**(新規): 画面下部の会話ボックス。話者名＋本文を逐次送り（A/タップ）、最後で閉じる。既存 overlay と同じパネル/入力様式・DotGothic16。
- **UIScene**: `showDialog/advanceDialog/hideDialog/isDialogOpen` 公開、`BaseMapScene.getUiScene` 型に追加。
- **村NPC(村長)**: `villageMap` に `VILLAGE_NPCS`/`npcAt`。NPCは障害物（乗れない）、隣接＋A で会話。女性騎士スプライト(`knight_f_idle_anim`)で描画。
- 台本は仮。Phase2(#25)で `game/story` へ移し物語進捗に連動。

検証: vue-tsc 0 / eslint 0 / vitest 177。ブラウザ実機で村長描画＋会話ボックス（「…よく来たな、探索者よ。」＋送り）を確認。既存ダンジョン挙動は無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 村にNPC（村長など）を追加し、名前ラベル付きで表示できるようになりました。
  - NPCに隣接して操作すると 会話を開始でき、画面下に話者名＋本文を順次表示します。
  - 会話中は 移動できず、NPCのいるマスにも進入できません。
  - 隣接していない場合は、これまでどおり 施設を操作できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->